### PR TITLE
feat(batch-22): close contact coordinate sync batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this project are documented in this file.
 - Backend tests for bootstrap real-name extraction/selection behavior (`backend/tests/test_bootstrap_known_star_systems.py`).
 
 ### Changed
+- Documented Batch 22 local-space snapshot compatibility fields and docking distance labeling behavior in the root and backend READMEs.
+- Clarified Batch 22 implementation status in the planning doc and added page-level regression coverage for `PORT` versus `SURFACE` docking distance labels during active docking approach.
 - Migrated frontend flight/scanner/chart/admin/comms/trade media playback from
   generated tone data URIs to manifest-resolved WAV assets in
   `frontend/public/audio/sfx`.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ cd backend && SITE_PACKAGES=$(../.venv/bin/python -c 'import site; print(site.ge
 
 - `GET /api/ships/{ship_id}/operations` returns human-readable `details`; dock/undock/jump entries resolve station names with `Station #<id>` fallback only if a name is unavailable.
 - `POST /api/ships/{ship_id}/jump` now arrives in destination system deep-space (no auto-dock), so docking remains an explicit follow-up step before trading.
+- `GET /api/ships/{ship_id}/local-contacts` and `GET /api/systems/{system_id}/local-chart` expose additive `snapshot_version` and `snapshot_generated_at` fields so the frontend can reject mixed scanner/chart state snapshots during active flight.
+- Docking distance semantics are explicit in flight surfaces: scanner/list views remain stable on center/surface-style distance labels, while active docking approach UI may switch to `PORT` distance labeling for the current approach target.

--- a/backend/README.md
+++ b/backend/README.md
@@ -215,9 +215,12 @@ cd backend
 - `POST /api/ships/{ship_id}/refuel` refuels a docked ship (full or partial via `amount`).
 - `POST /api/ships/{ship_id}/jump` consumes fuel and moves an in-space ship into destination system deep-space (supports `destination_station_id` and/or `destination_system_id`), requiring an explicit follow-up dock action for station services/trade.
 - `POST /api/ships/{ship_id}/crash-recovery` restores ship and player location to the latest safe checkpoint captured on safe events (dock, undock, jump).
+- `GET /api/ships/{ship_id}/local-contacts` returns local scanner contacts plus additive `snapshot_version` and `snapshot_generated_at` fields used for scanner/chart snapshot compatibility.
+- `GET /api/systems/{system_id}/local-chart` returns local chart bodies, mutable local-target state, and matching additive `snapshot_version` and `snapshot_generated_at` fields.
 - `GET /api/ships/{ship_id}/operations` returns recent operation log entries; `details` is a human-readable message and now resolves station names for dock/undock/jump events (with `Station #<id>` fallback only when a name is unavailable).
 - `GET /api/markets/{system_id}/summary` returns per-station aggregate market summary rows, including freshness fields (`updated_seconds_ago`, `stale`) and supports optional `simulate_ticks` read-only projection.
 - Interstellar comms messages are now queued with delivery timestamps and automatically transition from `queued` to `delivered` when due (`/api/comms` message/channel reads trigger due-message release).
+- Docking distance mode remains frontend-derived in the current Batch 22 implementation: backend contracts expose stable contact distances and snapshot metadata, while the focused approach HUD can label the active target using docking-port distance when that mode is in effect.
 
 ## Economy + Admin Logs Notes
 

--- a/backend/app/api/ships.py
+++ b/backend/app/api/ships.py
@@ -609,7 +609,7 @@ def _resolve_local_target_contact(
     system_id: int,
     contact_type: str,
     contact_id: int,
-) -> tuple[str, int, int, int, int | None]:
+) -> tuple[str, int, int, int, int | None, int]:
     """Resolve one local target contact and return label/position/legacy station id."""
 
     normalized_type = contact_type.strip().lower()
@@ -638,6 +638,7 @@ def _resolve_local_target_contact(
             int(station.position_y or 0),
             int(station.position_z or 0),
             int(station.id),
+            0,
         )
 
     body = (
@@ -658,6 +659,7 @@ def _resolve_local_target_contact(
         int(body.position_y or 0),
         int(body.position_z or 0),
         None,
+        int(body.radius_km or 0),
     )
 
 
@@ -1090,6 +1092,66 @@ def _apply_collision_damage(
     return absorbed_by_shields, applied_hull_damage
 
 
+def _resolve_collision_outcome(
+    *,
+    object_type: str,
+    severity: str,
+    recovered: bool,
+    destruction_triggered: bool,
+) -> str:
+    """Resolve a deterministic typed outcome for collision telemetry."""
+
+    if recovered:
+        return "checkpoint_recovery"
+
+    if object_type == "star":
+        if destruction_triggered:
+            return "thermal_cascade"
+        return "thermal_breach" if severity == "critical" else "thermal_shear"
+
+    if object_type == "planet":
+        return "planetary_impact"
+
+    if object_type == "station":
+        if destruction_triggered:
+            return "station_catastrophic_impact"
+        return "station_glancing_impact"
+
+    if object_type == "ship":
+        return "ship_heavy_impact" if severity == "critical" else "ship_glancing_impact"
+
+    return "collision_impact"
+
+
+def _collision_sfx_event_keys(
+    *,
+    severity: str,
+    object_type: str,
+    destruction_triggered: bool,
+    recovered: bool,
+) -> list[str]:
+    """Build canonical audio event keys for a collision response."""
+
+    event_keys: list[str] = [
+        "collision.critical_hit" if severity == "critical" else "collision.glancing_hit",
+    ]
+
+    if object_type == "star" or destruction_triggered:
+        event_keys.append("collision.warning_alarm")
+
+    if recovered:
+        event_keys.extend([
+            "ops.crash_recovery_start",
+            "ops.crash_recovery_complete",
+        ])
+
+    deduplicated: list[str] = []
+    for event_key in event_keys:
+        if event_key not in deduplicated:
+            deduplicated.append(event_key)
+    return deduplicated
+
+
 def _scanner_scene_coordinates(
     *,
     relative_x: int,
@@ -1392,6 +1454,9 @@ def get_ship_local_contacts(
                 radius_km=int(body.radius_km or 0),
                 orbit_radius_km=int(body.orbit_radius_km or 0),
                 parent_body_id=body.parent_body_id,
+                relative_x_km=relative_x,
+                relative_y_km=relative_y,
+                relative_z_km=relative_z,
                 scene_x=scene_x,
                 scene_y=scene_y,
                 scene_z=scene_z,
@@ -1463,6 +1528,9 @@ def get_ship_local_contacts(
                 station_archetype_shape=(
                     station_archetype.shape if station_archetype else None
                 ),
+                relative_x_km=relative_station_x,
+                relative_y_km=relative_station_y,
+                relative_z_km=relative_station_z,
                 scene_x=station_scene_x,
                 scene_y=station_scene_y,
                 scene_z=station_scene_z,
@@ -1523,6 +1591,9 @@ def get_ship_local_contacts(
                     contact_ship,
                     archetype_visual_map=ship_archetype_visual_map,
                 ),
+                relative_x_km=relative_ship_x,
+                relative_y_km=relative_ship_y,
+                relative_z_km=relative_ship_z,
                 scene_x=ship_scene_x,
                 scene_y=ship_scene_y,
                 scene_z=ship_scene_z,
@@ -2142,6 +2213,7 @@ def update_local_target(
         target_y,
         target_z,
         legacy_station_id,
+        target_radius_km,
     ) = _resolve_local_target_contact(
         db=db,
         system_id=int(system.id),
@@ -2187,11 +2259,14 @@ def update_local_target(
     vertical_km = _deterministic_offset_from_seed(seed_base * 11, 2, 5)
     lateral_sign = -1 if (seed_base % 2 == 0) else 1
     vertical_sign = -1 if ((seed_base // 3) % 2 == 0) else 1
+    longitudinal_offset_km = standoff_km
+    if contact_type in {"planet", "moon", "star"}:
+        longitudinal_offset_km += max(int(target_radius_km), 0)
 
-    ship.position_x = target_x + standoff_km
+    ship.position_x = target_x + longitudinal_offset_km
     ship.position_y = target_y + (vertical_sign * vertical_km)
     ship.position_z = target_z + (lateral_sign * lateral_km)
-    ship.velocity_x = max(1, standoff_km // 5)
+    ship.velocity_x = max(1, longitudinal_offset_km // 5)
     ship.velocity_y = 0
     ship.velocity_z = 0
     ship.status = "in-space"
@@ -2450,13 +2525,27 @@ def check_ship_collision(
     )
 
     recovered = False
-    if severity == "critical" and ship.hull_current <= 0:
+    destruction_triggered = severity == "critical" and ship.hull_current <= 0
+    if destruction_triggered:
         if ship.last_safe_recorded_at is not None:
             _restore_ship_to_safe_checkpoint(ship, current_user)
             ship.crash_recovery_count = int(ship.crash_recovery_count or 0) + 1
             ship.hull_current = max(
                 int(ship.hull_current or 0), max(ship.hull_max // 2, 1))
             recovered = True
+
+    resolved_outcome = _resolve_collision_outcome(
+        object_type=object_type,
+        severity=severity,
+        recovered=recovered,
+        destruction_triggered=destruction_triggered,
+    )
+    sfx_event_keys = _collision_sfx_event_keys(
+        severity=severity,
+        object_type=object_type,
+        destruction_triggered=destruction_triggered,
+        recovered=recovered,
+    )
 
     ship.version = (ship.version or 0) + 1
     _record_ship_operation(
@@ -2493,9 +2582,13 @@ def check_ship_collision(
         object_type=object_type,
         object_id=object_id,
         object_name=object_name,
+        collision_context_type=object_type,
+        resolved_outcome=resolved_outcome,
+        destruction_triggered=destruction_triggered,
         distance_km=round(distance_km, 2),
         shields_damage=shields_damage,
         hull_damage=hull_damage,
+        sfx_event_keys=sfx_event_keys,
         recovered=recovered,
         message=(
             f"{severity.title()} impact: {object_name} ({distance_km:.1f}km) · "

--- a/backend/app/schemas/ships.py
+++ b/backend/app/schemas/ships.py
@@ -142,6 +142,9 @@ class LocalScannerContact(BaseModel):
     orbiting_planet_name: str | None = None
     station_archetype_shape: str | None = None
     ship_visual_key: str | None = None
+    relative_x_km: int
+    relative_y_km: int
+    relative_z_km: int
     scene_x: float
     scene_y: float
     scene_z: float
@@ -162,8 +165,12 @@ class CollisionCheckResponse(BaseModel):
     object_type: str | None
     object_id: str | None
     object_name: str | None
+    collision_context_type: str | None = None
+    resolved_outcome: str = "none"
+    destruction_triggered: bool = False
     distance_km: float | None
     shields_damage: int
     hull_damage: int
+    sfx_event_keys: list[str] = Field(default_factory=list)
     recovered: bool
     message: str

--- a/backend/tests/test_players_ships_markets.py
+++ b/backend/tests/test_players_ships_markets.py
@@ -413,6 +413,22 @@ def test_local_target_lock_and_transfer_for_planet(client, db_session):
     assert transfer_payload["flight_locked_destination_contact_type"] == "planet"
     assert transfer_payload["flight_locked_destination_contact_id"] == planet_id
 
+    ship = db_session.query(Ship).filter(Ship.id == state["ship_id"]).first()
+    assert ship is not None
+    planet_body = (
+        db_session.query(CelestialBody)
+        .filter(CelestialBody.id == planet_id)
+        .first()
+    )
+    assert planet_body is not None
+
+    center_distance_km = math.sqrt(
+        ((int(ship.position_x or 0) - int(planet_body.position_x or 0)) ** 2)
+        + ((int(ship.position_y or 0) - int(planet_body.position_y or 0)) ** 2)
+        + ((int(ship.position_z or 0) - int(planet_body.position_z or 0)) ** 2)
+    )
+    assert center_distance_km > float(planet_body.radius_km or 0)
+
 
 def test_ship_visual_key_uses_archetype_lookup_not_ship_name(client, db_session):
     headers = auth_headers_for(client, "visual-key@example.com", "visual-key")
@@ -827,8 +843,18 @@ def test_collision_check_applies_glancing_damage_and_logs_event(client, db_sessi
     assert post_grace_payload["severity"] in {"glancing", "critical"}
     assert post_grace_payload["object_type"] in {
         "station", "ship", "planet", "star"}
+    assert post_grace_payload["collision_context_type"] == post_grace_payload["object_type"]
+    assert isinstance(post_grace_payload["resolved_outcome"], str)
+    assert isinstance(post_grace_payload["destruction_triggered"], bool)
     assert post_grace_payload["shields_damage"] >= 0
     assert post_grace_payload["hull_damage"] >= 0
+    assert isinstance(post_grace_payload["sfx_event_keys"], list)
+    assert len(post_grace_payload["sfx_event_keys"]) >= 1
+    assert (
+        "collision.critical_hit"
+        if post_grace_payload["severity"] == "critical"
+        else "collision.glancing_hit"
+    ) in post_grace_payload["sfx_event_keys"]
     assert post_grace_payload["ship"]["shields_current"] <= 100
     assert post_grace_payload["ship"]["hull_current"] <= 100
 
@@ -899,6 +925,10 @@ def test_collision_check_critical_impact_triggers_checkpoint_recovery(
     assert payload["collision"] is True
     assert payload["severity"] == "critical"
     assert payload["recovered"] is True
+    assert payload["destruction_triggered"] is True
+    assert payload["resolved_outcome"] == "checkpoint_recovery"
+    assert "ops.crash_recovery_start" in payload["sfx_event_keys"]
+    assert "ops.crash_recovery_complete" in payload["sfx_event_keys"]
     assert payload["ship"]["crash_recovery_count"] == 1
     assert payload["ship"]["hull_current"] > 0
 
@@ -977,6 +1007,8 @@ def test_collision_check_suppresses_locked_station_impact_during_docking_approac
     assert payload["severity"] == "none"
     assert payload["object_type"] == "station"
     assert payload["object_id"] == f"station-{target_station.id}"
+    assert payload["resolved_outcome"] == "none"
+    assert payload["sfx_event_keys"] == []
     assert payload["message"].startswith(
         "Docking computer safety corridor active")
 
@@ -1368,6 +1400,9 @@ def test_ship_local_contacts_returns_ships_stations_planet_and_star(client, db_s
         assert station_contact["host_body_id"] is not None
         assert isinstance(station_contact["orbit_phase_deg"], int)
         assert station_contact["station_archetype_shape"] == "coriolis"
+        assert isinstance(station_contact["relative_x_km"], int)
+        assert isinstance(station_contact["relative_y_km"], int)
+        assert isinstance(station_contact["relative_z_km"], int)
         assert isinstance(station_contact["scene_x"], (float, int))
         assert isinstance(station_contact["scene_y"], (float, int))
         assert isinstance(station_contact["scene_z"], (float, int))

--- a/frontend/src/app/page.scanner-flight.test.tsx
+++ b/frontend/src/app/page.scanner-flight.test.tsx
@@ -11,9 +11,16 @@ vi.mock("next/dynamic", () => ({
       focusedContact: { name?: string } | null;
       jumpPhase?: string;
       cameraMode?: "boresight" | "cockpit";
+      scannerRangeKm?: number;
       showContactLabels?: boolean;
       waypointContactId?: string | null;
-      celestialAnchors?: Array<{ id: string; body_kind?: string }>;
+      celestialAnchors?: Array<{
+        id: string;
+        body_kind?: string;
+        relative_x_km?: number;
+        relative_y_km?: number;
+        relative_z_km?: number;
+      }>;
       dockingApproachContactId?: string | null;
       onDockingApproachComplete?: () => void;
       scannerContacts?: Array<{ id: string; distance_km?: number }>;
@@ -22,6 +29,9 @@ vi.mock("next/dynamic", () => ({
         relative_x: number;
         relative_y: number;
         relative_z: number;
+        relative_x_km?: number;
+        relative_y_km?: number;
+        relative_z_km?: number;
         forward_distance: number;
         plane_x: number;
         plane_y: number;
@@ -41,6 +51,7 @@ vi.mock("next/dynamic", () => ({
         focusedContact,
         jumpPhase,
         cameraMode,
+        scannerRangeKm,
         showContactLabels,
         waypointContactId,
         celestialAnchors,
@@ -83,6 +94,9 @@ vi.mock("next/dynamic", () => ({
             relative_x: isPrimaryStation ? 90 : (index + 1) * 10,
             relative_y: 0,
             relative_z: -60,
+            relative_x_km: isPrimaryStation ? 90 : (index + 1) * 10,
+            relative_y_km: 0,
+            relative_z_km: -60,
             forward_distance: 60,
             plane_x: isPrimaryStation ? -0.9 : 0.2,
             plane_y: 0.4,
@@ -106,7 +120,12 @@ vi.mock("next/dynamic", () => ({
       }, [onScannerTelemetryChange, scannerContacts]);
 
       useEffect(() => {
-        if (!dockingApproachContactId) {
+        const disableDockingApproachAutoComplete = Boolean(
+          (globalThis as unknown as {
+            __disableDockingApproachAutoComplete?: boolean;
+          }).__disableDockingApproachAutoComplete,
+        );
+        if (!dockingApproachContactId || disableDockingApproachAutoComplete) {
           return;
         }
 
@@ -130,6 +149,9 @@ vi.mock("next/dynamic", () => ({
           <div data-testid="flight-scene-camera-mode">
             {cameraMode ?? "boresight"}
           </div>
+          <div data-testid="flight-scene-scanner-range">
+            {String(scannerRangeKm ?? 25)}
+          </div>
           <div data-testid="flight-scene-show-contact-labels">
             {showContactLabels ? "on" : "off"}
           </div>
@@ -139,6 +161,20 @@ vi.mock("next/dynamic", () => ({
           <div data-testid="flight-scene-moon-anchor-count">
             {String(moonAnchorCount)}
           </div>
+          {Array.isArray(celestialAnchors)
+            ? celestialAnchors.map((anchor) => (
+              <div
+                key={anchor.id}
+                data-testid={`flight-scene-celestial-anchor-${anchor.id}`}
+              >
+                {[
+                  anchor.relative_x_km ?? "na",
+                  anchor.relative_y_km ?? "na",
+                  anchor.relative_z_km ?? "na",
+                ].join(",")}
+              </div>
+            ))
+            : null}
         </>
       );
     }
@@ -150,6 +186,7 @@ vi.mock("next/dynamic", () => ({
 describe("Home scanner to flight scene wiring", () => {
   let shipTelemetryPayload: Record<string, unknown>;
   let scannerContactsPayload: Array<Record<string, unknown>>;
+  let scannerContactsGenerationVersion: number;
   let localChartPayload: Record<string, unknown>;
   let localChartStatusCode: number;
   let localChartErrorMessage: string;
@@ -164,6 +201,7 @@ describe("Home scanner to flight scene wiring", () => {
     window.localStorage.setItem("elite_token", "test-token");
     window.localStorage.setItem("elite_user_id", "1");
     (globalThis as unknown as { __scannerTelemetryOverrides?: Record<string, unknown> }).__scannerTelemetryOverrides = {};
+    (globalThis as unknown as { __disableDockingApproachAutoComplete?: boolean }).__disableDockingApproachAutoComplete = false;
 
     shipTelemetryPayload = {
       id: 1,
@@ -614,6 +652,50 @@ describe("Home scanner to flight scene wiring", () => {
     });
 
     expect(screen.getByText("Dock Target Range")).toBeInTheDocument();
+  });
+
+  it("labels docking approach range using PORT mode for the active approach target", async () => {
+    (globalThis as unknown as {
+      __scannerTelemetryOverrides?: Record<string, Partial<{
+        distance: number;
+        distance_mode: "surface" | "port";
+      }>>;
+    }).__scannerTelemetryOverrides = {
+      "station-101": {
+        distance: 3.4,
+        distance_mode: "port",
+      },
+    };
+    (globalThis as unknown as { __disableDockingApproachAutoComplete?: boolean }).__disableDockingApproachAutoComplete = true;
+
+    render(
+      <ToastProvider>
+        <Home />
+      </ToastProvider>,
+    );
+
+    const flightModeButtons = await screen.findAllByRole("button", {
+      name: /^Flight$/,
+    });
+    fireEvent.click(flightModeButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("flight-scene-focused-contact").textContent,
+      ).toBe("Vega Tradeport");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Dock$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^Cancel Docking$/i })).toBeInTheDocument();
+      expect(
+        screen.getByText(/Vega Tradeport · 3\.4 km PORT \/ 40\.0 km · IN RANGE/),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Docking computer active: autopilot approach is guiding to docking port\./)).toBeInTheDocument();
+    expect(dockRequestBodies.length).toBe(0);
   });
 
   it("applies scanner grid range cap and allows expanding range via preset selector", async () => {

--- a/frontend/src/app/page.scanner-flight.test.tsx
+++ b/frontend/src/app/page.scanner-flight.test.tsx
@@ -10,7 +10,9 @@ vi.mock("next/dynamic", () => ({
     function MockFlightScene(props: {
       focusedContact: { name?: string } | null;
       jumpPhase?: string;
+      cameraMode?: "boresight" | "cockpit";
       showContactLabels?: boolean;
+      waypointContactId?: string | null;
       celestialAnchors?: Array<{ id: string; body_kind?: string }>;
       dockingApproachContactId?: string | null;
       onDockingApproachComplete?: () => void;
@@ -38,7 +40,9 @@ vi.mock("next/dynamic", () => ({
         onDockingApproachComplete,
         focusedContact,
         jumpPhase,
+        cameraMode,
         showContactLabels,
+        waypointContactId,
         celestialAnchors,
         scannerContacts,
         onScannerTelemetryChange,
@@ -123,8 +127,14 @@ vi.mock("next/dynamic", () => ({
           <div data-testid="flight-scene-jump-phase">
             {jumpPhase ?? "idle"}
           </div>
+          <div data-testid="flight-scene-camera-mode">
+            {cameraMode ?? "boresight"}
+          </div>
           <div data-testid="flight-scene-show-contact-labels">
             {showContactLabels ? "on" : "off"}
+          </div>
+          <div data-testid="flight-scene-waypoint-contact-id">
+            {waypointContactId ?? "none"}
           </div>
           <div data-testid="flight-scene-moon-anchor-count">
             {String(moonAnchorCount)}
@@ -752,7 +762,7 @@ describe("Home scanner to flight scene wiring", () => {
     expect(planetRow.textContent).toContain("1.60M km");
   });
 
-  it("updates scanner contact row distance from live telemetry updates", async () => {
+  it("keeps scanner contact row distance pinned to snapshot telemetry", async () => {
     scannerContactsPayload = [
       {
         id: "station-101",
@@ -790,7 +800,7 @@ describe("Home scanner to flight scene wiring", () => {
 
     await waitFor(() => {
       const stationRow = screen.getByTestId("scanner-contact-row-station-101");
-      expect(stationRow.textContent).toContain("27.0 km");
+      expect(stationRow.textContent).toContain("42.0 km");
     });
 
     (globalThis as unknown as {
@@ -809,7 +819,7 @@ describe("Home scanner to flight scene wiring", () => {
 
     await waitFor(() => {
       const stationRow = screen.getByTestId("scanner-contact-row-station-101");
-      expect(stationRow.textContent).toContain("5.0 km");
+      expect(stationRow.textContent).toContain("42.0 km");
     });
   });
 
@@ -1107,6 +1117,46 @@ describe("Home scanner to flight scene wiring", () => {
     fireEvent.click(labelsToggle);
 
     expect(screen.getByTestId("flight-scene-show-contact-labels").textContent).toBe("on");
+  });
+
+  it("persists flight camera mode selection", async () => {
+    const firstRender = render(
+      <ToastProvider>
+        <Home />
+      </ToastProvider>,
+    );
+
+    const flightModeButtons = await screen.findAllByRole("button", {
+      name: /^Flight$/,
+    });
+    fireEvent.click(flightModeButtons[0]);
+
+    expect(screen.getByTestId("flight-scene-camera-mode").textContent).toBe("boresight");
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    const cameraModeSelect = await screen.findByTestId("flight-setting-camera-mode");
+    fireEvent.change(cameraModeSelect, { target: { value: "cockpit" } });
+
+    expect(window.localStorage.getItem("elite_flight_camera_mode")).toBe("cockpit");
+    expect(screen.getByTestId("flight-scene-camera-mode").textContent).toBe("cockpit");
+
+    firstRender.unmount();
+
+    render(
+      <ToastProvider>
+        <Home />
+      </ToastProvider>,
+    );
+
+    const flightModeButtonsReloaded = await screen.findAllByRole("button", {
+      name: /^Flight$/,
+    });
+    fireEvent.click(flightModeButtonsReloaded[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect((await screen.findByTestId("flight-setting-camera-mode") as HTMLSelectElement).value)
+      .toBe("cockpit");
+    expect(screen.getByTestId("flight-scene-camera-mode").textContent).toBe("cockpit");
   });
 
   it("persists flight audio settings toggles", async () => {
@@ -2417,6 +2467,12 @@ describe("Home scanner to flight scene wiring", () => {
     }))[0];
     fireEvent.click(flightModeButton);
 
+    await waitFor(() => {
+      expect(screen.getByTestId("flight-scene-waypoint-contact-id").textContent).toBe(
+        "planet-201",
+      );
+    });
+
     const jumpButton = screen.getByRole("button", { name: /^System Jump$/i });
     expect(jumpButton).toBeEnabled();
     fireEvent.click(jumpButton);
@@ -2901,7 +2957,7 @@ describe("Home scanner to flight scene wiring", () => {
     });
   });
 
-  it("plots in-view scanner blips using camera FOV alignment", async () => {
+  it("plots scanner blips using canonical plane projection", async () => {
     render(
       <ToastProvider>
         <Home />
@@ -2918,7 +2974,7 @@ describe("Home scanner to flight scene wiring", () => {
     await waitFor(() => {
       const leftValue = Number.parseFloat(stationBlip.style.left.replace("%", ""));
       expect(Number.isFinite(leftValue)).toBe(true);
-      expect(leftValue).toBeGreaterThan(50);
+      expect(leftValue).toBeLessThan(50);
     });
   });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -38,6 +38,7 @@ const LOCAL_CHART_SORT_STORAGE_KEY = "elite_local_chart_sort";
 const SCANNER_SELECTED_CONTACT_STORAGE_KEY = "elite_scanner_selected_contact";
 const SCANNER_RANGE_STORAGE_KEY = "elite_scanner_range_km";
 const FLIGHT_CONTACT_LABELS_STORAGE_KEY = "elite_flight_contact_labels";
+const FLIGHT_CAMERA_MODE_STORAGE_KEY = "elite_flight_camera_mode";
 const FLIGHT_SCANNER_DEBUG_STORAGE_KEY = "elite_flight_scanner_debug";
 const FLIGHT_AUDIO_ENABLED_STORAGE_KEY = "elite_flight_audio_enabled";
 const FLIGHT_REDUCED_AUDIO_STORAGE_KEY = "elite_flight_reduced_audio";
@@ -67,6 +68,7 @@ const FLIGHT_PHASE = {
 
 type FlightJumpPhase = (typeof FLIGHT_PHASE)[keyof typeof FLIGHT_PHASE];
 type FlightRenderProfile = "performance" | "balanced" | "cinematic";
+type FlightCameraMode = "boresight" | "cockpit";
 type LocalTargetStatus =
   | "none"
   | "in-system-locked"
@@ -694,6 +696,9 @@ type ScannerContact = {
   orbiting_planet_name?: string | null;
   station_archetype_shape?: string | null;
   ship_visual_key?: string | null;
+  relative_x_km?: number;
+  relative_y_km?: number;
+  relative_z_km?: number;
   scene_x: number;
   scene_y: number;
   scene_z: number;
@@ -729,6 +734,23 @@ type ScannerContactsResponse = {
   system_name: string;
   generation_version: number;
   contacts: ScannerContact[];
+};
+
+type FlightSceneCelestialAnchor = {
+  id: string;
+  contact_type: "planet" | "moon" | "star";
+  name: string;
+  distance_km: number;
+  orbiting_planet_name?: string | null;
+  body_kind: "star" | "planet" | "moon";
+  body_type?: string | null;
+  radius_km?: number | null;
+  relative_x_km?: number;
+  relative_y_km?: number;
+  relative_z_km?: number;
+  presentation_x: number;
+  presentation_y: number;
+  presentation_z: number;
 };
 
 type LocalChartBody = {
@@ -805,6 +827,9 @@ type ScannerLiveContact = {
   relative_x: number;
   relative_y: number;
   relative_z: number;
+  relative_x_km?: number;
+  relative_y_km?: number;
+  relative_z_km?: number;
   forward_distance: number;
   plane_x: number;
   plane_y: number;
@@ -822,7 +847,32 @@ type FlightDockingApproachProgress = {
   progress: number;
   distanceKm: number;
   targetName: string;
-  stage: "hold-entry" | "hold-align" | "final-approach";
+  stage: "hold-entry" | "hold-align" | "tunnel-entry" | "final-approach";
+};
+
+type FlightDockingDebugPayload = {
+  event: string;
+  contactId: string;
+  targetName?: string;
+  stage?: "hold-entry" | "hold-align" | "tunnel-entry" | "final-approach";
+  reason?: string;
+  distanceToPortKm?: number;
+  distanceToApproachPointKm?: number;
+  stageDistanceRemainingKm?: number;
+  reticleAlignmentCosine?: number;
+  corridorLateralOffsetKm?: number;
+  shouldMatchStationRotation?: boolean;
+  stationRotationRadians?: number;
+  shipSpeedKmPerSec?: number;
+  shipPosition?: { x: number; y: number; z: number };
+  portCorePosition?: { x: number; y: number; z: number };
+  portApproachPosition?: { x: number; y: number; z: number };
+  stationCenter?: { x: number; y: number; z: number };
+  portVisibleOnScreen?: boolean;
+  portCenteredOnScreen?: boolean;
+  portScreenOffsetX?: number;
+  portScreenOffsetY?: number;
+  portScreenDepthKm?: number;
 };
 
 type FlightSpawnDirective = {
@@ -878,9 +928,13 @@ type CollisionCheckResponse = {
   object_type: string | null;
   object_id: string | null;
   object_name: string | null;
+  collision_context_type?: string | null;
+  resolved_outcome?: string;
+  destruction_triggered?: boolean;
   distance_km: number | null;
   shields_damage: number;
   hull_damage: number;
+  sfx_event_keys?: string[];
   recovered: boolean;
   message: string;
 };
@@ -1269,7 +1323,7 @@ const FLIGHT_CELESTIAL_MIN_ORBIT_STEP_UNITS = 68;
 const buildFlightCelestialAnchors = (
   localChartData: LocalChartResponse,
   scannerContacts: ScannerContact[],
-): ScannerContact[] => {
+): FlightSceneCelestialAnchor[] => {
   const scannerContactById = new Map(scannerContacts.map((contact) => [contact.id, contact]));
   const star = localChartData.star;
 
@@ -1375,14 +1429,13 @@ const buildFlightCelestialAnchors = (
           ? "moon"
           : "planet",
       distance_km: scannerMatch?.distance_km ?? fallbackDistanceKm,
-      bearing_x: scannerMatch?.bearing_x ?? 0,
-      bearing_y: scannerMatch?.bearing_y ?? 0,
       orbiting_planet_name: scannerMatch?.orbiting_planet_name ?? null,
-      station_archetype_shape: null,
-      ship_visual_key: null,
-      scene_x: body.rel_x * directionScale,
-      scene_y: body.rel_y * directionScale,
-      scene_z: body.rel_z * directionScale,
+      relative_x_km: body.rel_x,
+      relative_y_km: body.rel_y,
+      relative_z_km: body.rel_z,
+      presentation_x: body.rel_x * directionScale,
+      presentation_y: body.rel_y * directionScale,
+      presentation_z: body.rel_z * directionScale,
       body_kind: body.body_kind,
       body_type: body.body_type,
       radius_km: body.radius_km,
@@ -1661,6 +1714,20 @@ export default function Home() {
   const [flightJumpCooldownSeconds, setFlightJumpCooldownSeconds] = useState(0);
   const [flightRenderProfile, setFlightRenderProfile] = useState<FlightRenderProfile>("balanced");
   const [showFlightSettings, setShowFlightSettings] = useState(false);
+  const [flightCameraMode, setFlightCameraMode] = useState<FlightCameraMode>(() => {
+    if (typeof window === "undefined") {
+      return "boresight";
+    }
+
+    try {
+      const stored = window.localStorage.getItem(FLIGHT_CAMERA_MODE_STORAGE_KEY);
+      return stored === "cockpit" || stored === "boresight"
+        ? stored
+        : "boresight";
+    } catch {
+      return "boresight";
+    }
+  });
   const [showFlightContactLabels, setShowFlightContactLabels] = useState(() => {
     if (typeof window === "undefined") {
       return false;
@@ -1800,8 +1867,8 @@ export default function Home() {
     y: number;
     z: number;
   } | null>(null);
+  const dockingDebugSequenceRef = useRef(0);
   const authExpiredHandledRef = useRef(false);
-  const activeProximityCollisionContactIdRef = useRef<string | null>(null);
   const systemChartOpenCountRef = useRef(0);
   const systemChartSyncSuccessCountRef = useRef(0);
   const systemChartSyncFailureCountRef = useRef(0);
@@ -3104,6 +3171,47 @@ export default function Home() {
     token,
   ]);
 
+  const emitDockingDebugLog = useCallback((
+    event: string,
+    payload?: Record<string, unknown>,
+  ): void => {
+    const dockingPhaseActive = (
+      flightDockingApproachTargetStationId !== null
+      || flightJumpPhase === FLIGHT_PHASE.DOCKING_APPROACH
+    );
+    if (!dockingPhaseActive && event !== "dock-command") {
+      return;
+    }
+
+    const sequence = dockingDebugSequenceRef.current + 1;
+    dockingDebugSequenceRef.current = sequence;
+    const shipPosition = shipTelemetry
+      ? {
+        x: shipTelemetry.position_x,
+        y: shipTelemetry.position_y,
+        z: shipTelemetry.position_z,
+      }
+      : null;
+
+    console.info("[DockingDebug]", {
+      sequence,
+      timestamp: new Date().toISOString(),
+      event,
+      jumpPhase: flightJumpPhase,
+      dockingApproachActive: flightDockingApproachTargetStationId !== null,
+      dockTargetContactId: flightDockingApproachTargetContactId,
+      dockingComputerRangeKm: shipTelemetry?.docking_computer_range_km ?? null,
+      shipStatus: shipTelemetry?.status ?? null,
+      shipPosition,
+      ...payload,
+    });
+  }, [
+    flightDockingApproachTargetContactId,
+    flightDockingApproachTargetStationId,
+    flightJumpPhase,
+    shipTelemetry,
+  ]);
+
   const fetchScannerContacts = useCallback(async (options?: { silent?: boolean }) => {
     if (!token) {
       setScannerContacts([]);
@@ -3158,11 +3266,12 @@ export default function Home() {
       const payload = data as ScannerContactsResponse;
       const contacts = Array.isArray(payload.contacts) ? payload.contacts : [];
       setScannerContacts(contacts);
-      dispatchFlightAudioEvent("scanner.ping", {
-        contacts_count: contacts.length,
-        system_id: payload.system_id,
-      });
-      setScannerLiveContacts([]);
+      if (!options?.silent) {
+        dispatchFlightAudioEvent("scanner.ping", {
+          contacts_count: contacts.length,
+          system_id: payload.system_id,
+        });
+      }
       setScannerSystemId(Number.isInteger(payload.system_id) ? payload.system_id : null);
       setScannerSystemName(payload.system_name || null);
       setScannerGenerationVersion(
@@ -3499,6 +3608,58 @@ export default function Home() {
     }
   }, [flightJumpPhase]);
 
+  const dispatchCollisionAudioEvents = useCallback((payload: CollisionCheckResponse) => {
+    const defaultEventKeys: FlightAudioEventName[] = [
+      payload.severity === "critical" ? "collision.critical_hit" : "collision.glancing_hit",
+      ...(payload.recovered
+        ? ["ops.crash_recovery_start", "ops.crash_recovery_complete"]
+        : []),
+    ];
+
+    const parsedEventKeys = Array.isArray(payload.sfx_event_keys)
+      ? payload.sfx_event_keys
+        .map((eventKey) => parseFlightAudioEventName(eventKey))
+        .filter((eventKey): eventKey is FlightAudioEventName => eventKey !== null)
+      : [];
+
+    const eventKeys = parsedEventKeys.length > 0 ? parsedEventKeys : defaultEventKeys;
+    eventKeys.forEach((eventKey) => {
+      dispatchFlightAudioEvent(eventKey, {
+        object_id: payload.object_id ?? null,
+        object_type: payload.object_type ?? payload.collision_context_type ?? null,
+        distance_km: payload.distance_km ?? null,
+        resolved_outcome: payload.resolved_outcome ?? null,
+        destruction_triggered: Boolean(payload.destruction_triggered),
+        recovered: Boolean(payload.recovered),
+      });
+    });
+  }, [dispatchFlightAudioEvent]);
+
+  const mergeCollisionTelemetryShip = useCallback((payload: CollisionCheckResponse): ShipTelemetry => {
+    const payloadShip = payload.ship;
+    const currentShip = shipTelemetry;
+    if (!currentShip) {
+      return payloadShip;
+    }
+
+    const payloadShipStatus = (payloadShip.status || "").trim().toLowerCase();
+    const preserveInSpacePosition = (
+      !payload.recovered
+      && payloadShipStatus === "in-space"
+      && currentShip.status === "in-space"
+    );
+    if (!preserveInSpacePosition) {
+      return payloadShip;
+    }
+
+    return {
+      ...payloadShip,
+      position_x: currentShip.position_x,
+      position_y: currentShip.position_y,
+      position_z: currentShip.position_z,
+    };
+  }, [shipTelemetry]);
+
   const fetchCollisionTelemetry = useCallback(async (options?: { silent?: boolean }) => {
     if (!token) {
       setFlightCollisionStatus("Collision monitor idle.");
@@ -3530,24 +3691,13 @@ export default function Home() {
       }
 
       const payload = data as CollisionCheckResponse;
-      setShipTelemetry(payload.ship);
+      setShipTelemetry(mergeCollisionTelemetryShip(payload));
       syncJumpCooldownFromShipTelemetry(payload.ship);
       syncFlightStateFromShipTelemetry(payload.ship);
       setFlightCollisionStatus(sanitizeCollisionStatusMessage(payload.message));
 
       if (payload.collision) {
-        dispatchFlightAudioEvent(
-          payload.severity === "critical" ? "collision.critical_hit" : "collision.glancing_hit",
-          {
-            object_id: payload.object_id ?? null,
-            object_type: payload.object_type ?? null,
-            distance_km: payload.distance_km ?? null,
-          },
-        );
-        dispatchFlightAudioEvent("ops.crash_recovery_start", {
-          recovered: Boolean(payload.recovered),
-          object_id: payload.object_id ?? null,
-        });
+        dispatchCollisionAudioEvents(payload);
         const signature = `${payload.severity}:${payload.object_id ?? "unknown"}:${payload.recovered ? "r" : "n"}`;
         const severityLabel = payload.severity.toUpperCase();
         const objectLabel = payload.object_name ?? payload.object_type ?? "unknown object";
@@ -3592,7 +3742,8 @@ export default function Home() {
       setFlightRecentImpacts([]);
     }
   }, [
-    dispatchFlightAudioEvent,
+    dispatchCollisionAudioEvents,
+    mergeCollisionTelemetryShip,
     shipId,
     showToast,
     syncFlightStateFromShipTelemetry,
@@ -4305,7 +4456,173 @@ export default function Home() {
 
   const localChartRows = useMemo<(LocalChartRow | null)[]>(() => {
     const minimumRows = 8;
+    const scannerLiveContactById = new Map(
+      scannerLiveContacts.map((liveContact) => [liveContact.id, liveContact]),
+    );
+    const scannerContactById = new Map(scannerContacts.map((contact) => [contact.id, contact]));
+    const anchoredShipWorldPosition = (() => {
+      if (!localChartData?.stations?.length) {
+        return null;
+      }
+
+      const stationById = new Map(
+        localChartData.stations.map((station) => [station.id, station]),
+      );
+      const preferredStationContactIds: string[] = [];
+      if (flightDockingApproachTargetContactId?.startsWith("station-")) {
+        preferredStationContactIds.push(flightDockingApproachTargetContactId);
+      }
+      if (scannerSelectedContactId?.startsWith("station-")) {
+        preferredStationContactIds.push(scannerSelectedContactId);
+      }
+      if (jumpTargetStationId && Number.isInteger(jumpTargetStationId) && jumpTargetStationId > 0) {
+        preferredStationContactIds.push(`station-${jumpTargetStationId}`);
+      }
+
+      const resolveAnchoredPosition = (liveContact: ScannerLiveContact | undefined): {
+        x: number;
+        y: number;
+        z: number;
+      } | null => {
+        if (!liveContact) {
+          return null;
+        }
+
+        const scannerContact = scannerContactById.get(liveContact.id);
+        if (!scannerContact || scannerContact.contact_type !== "station") {
+          return null;
+        }
+
+        const stationId = parseStationContactId(scannerContact.id);
+        if (!stationId) {
+          return null;
+        }
+
+        const station = stationById.get(stationId);
+        if (!station) {
+          return null;
+        }
+
+        return {
+          x: station.position_x - (
+            Number.isFinite(liveContact.relative_x_km)
+              ? Number(liveContact.relative_x_km)
+              : liveContact.relative_x * STATION_SCENE_TO_WORLD_SCALE_XZ
+          ),
+          y: station.position_y - (
+            Number.isFinite(liveContact.relative_y_km)
+              ? Number(liveContact.relative_y_km)
+              : liveContact.relative_y * STATION_SCENE_TO_WORLD_SCALE_Y
+          ),
+          z: station.position_z - (
+            Number.isFinite(liveContact.relative_z_km)
+              ? Number(liveContact.relative_z_km)
+              : liveContact.relative_z * STATION_SCENE_TO_WORLD_SCALE_XZ
+          ),
+        };
+      };
+
+      for (const preferredContactId of preferredStationContactIds) {
+        const anchoredPosition = resolveAnchoredPosition(
+          scannerLiveContactById.get(preferredContactId),
+        );
+        if (anchoredPosition) {
+          return anchoredPosition;
+        }
+      }
+
+      const nearestLiveStationContact = scannerLiveContacts
+        .filter((liveContact) => {
+          const scannerContact = scannerContactById.get(liveContact.id);
+          return scannerContact?.contact_type === "station";
+        })
+        .sort((left, right) => left.distance - right.distance)[0];
+
+      return resolveAnchoredPosition(nearestLiveStationContact);
+    })();
+    const scannerContactWorldPositionById = (() => {
+      const map = new Map<string, { x: number; y: number; z: number }>();
+      if (!anchoredShipWorldPosition) {
+        return map;
+      }
+
+      scannerContacts.forEach((contact) => {
+        const liveContact = scannerLiveContactById.get(contact.id);
+        const relativeXKm = Number.isFinite(liveContact?.relative_x_km)
+          ? Number(liveContact?.relative_x_km)
+          : Number.isFinite(contact.relative_x_km)
+            ? Number(contact.relative_x_km)
+            : null;
+        const relativeYKm = Number.isFinite(liveContact?.relative_y_km)
+          ? Number(liveContact?.relative_y_km)
+          : Number.isFinite(contact.relative_y_km)
+            ? Number(contact.relative_y_km)
+            : null;
+        const relativeZKm = Number.isFinite(liveContact?.relative_z_km)
+          ? Number(liveContact?.relative_z_km)
+          : Number.isFinite(contact.relative_z_km)
+            ? Number(contact.relative_z_km)
+            : null;
+
+        if (
+          relativeXKm === null
+          || relativeYKm === null
+          || relativeZKm === null
+        ) {
+          return;
+        }
+
+        map.set(contact.id, {
+          x: anchoredShipWorldPosition.x + relativeXKm,
+          y: anchoredShipWorldPosition.y + relativeYKm,
+          z: anchoredShipWorldPosition.z + relativeZKm,
+        });
+      });
+
+      return map;
+    })();
     const isLayerVisible = (contactType: ScannerContactType): boolean => localChartLayers[contactType];
+    const resolveFallbackChartPosition = (contact: ScannerContact): {
+      x: number;
+      y: number;
+      z: number;
+    } => {
+      const liveContact = scannerLiveContactById.get(contact.id);
+      const relativeXKm = Number.isFinite(liveContact?.relative_x_km)
+        ? Number(liveContact?.relative_x_km)
+        : Number.isFinite(contact.relative_x_km)
+          ? Number(contact.relative_x_km)
+          : null;
+      const relativeYKm = Number.isFinite(liveContact?.relative_y_km)
+        ? Number(liveContact?.relative_y_km)
+        : Number.isFinite(contact.relative_y_km)
+          ? Number(contact.relative_y_km)
+          : null;
+      const relativeZKm = Number.isFinite(liveContact?.relative_z_km)
+        ? Number(liveContact?.relative_z_km)
+        : Number.isFinite(contact.relative_z_km)
+          ? Number(contact.relative_z_km)
+          : null;
+
+      if (
+        relativeXKm !== null
+        && relativeYKm !== null
+        && relativeZKm !== null
+      ) {
+        return {
+          x: relativeXKm,
+          y: relativeYKm,
+          z: relativeZKm,
+        };
+      }
+
+      return {
+        x: contact.scene_x,
+        y: contact.scene_y,
+        z: contact.scene_z,
+      };
+    };
+
     const isRowVisible = (row: LocalChartRow): boolean => {
       if (row.body_kind === "star") {
         return localChartLayers.star;
@@ -4327,22 +4644,25 @@ export default function Home() {
         .filter((contact) => isLayerVisible(contact.contact_type))
         .sort((left, right) => left.distance_km - right.distance_km)
         .slice(0, minimumRows)
-        .map((contact) => ({
-          id: contact.id,
-          contact_type: contact.contact_type,
-          body_kind: contact.contact_type,
-          body_type: null,
-          name: contact.name,
-          visual_label: contact.contact_type === "ship"
-            ? (contact.ship_visual_key ?? "cobra-mk1")
-            : "—",
-          radius_km: null,
-          distance_km: contact.distance_km,
-          orbit_label: contact.orbiting_planet_name ?? "—",
-          chart_x: contact.scene_x,
-          chart_y: contact.scene_y,
-          chart_z: contact.scene_z,
-        }));
+        .map((contact) => {
+          const position = resolveFallbackChartPosition(contact);
+          return {
+            id: contact.id,
+            contact_type: contact.contact_type,
+            body_kind: contact.contact_type,
+            body_type: null,
+            name: contact.name,
+            visual_label: contact.contact_type === "ship"
+              ? (contact.ship_visual_key ?? "cobra-mk1")
+              : "—",
+            radius_km: null,
+            distance_km: contact.distance_km,
+            orbit_label: contact.orbiting_planet_name ?? "—",
+            chart_x: position.x,
+            chart_y: position.y,
+            chart_z: position.z,
+          };
+        });
 
       if (fallback.length >= minimumRows) {
         return fallback;
@@ -4354,7 +4674,6 @@ export default function Home() {
       ];
     }
 
-    const scannerContactById = new Map(scannerContacts.map((contact) => [contact.id, contact]));
     const planetNameById = new Map<number, string>();
     localChartData.planets.forEach((planet) => {
       planetNameById.set(planet.id, planet.name);
@@ -4362,6 +4681,7 @@ export default function Home() {
 
     const rows: LocalChartRow[] = [];
     const starId = `star-${localChartData.star.id}`;
+    const starWorldPosition = scannerContactWorldPositionById.get(starId);
     rows.push({
       id: starId,
       contact_type: "star",
@@ -4375,13 +4695,14 @@ export default function Home() {
       radius_km: localChartData.star.radius_km,
       distance_km: scannerContactById.get(starId)?.distance_km ?? null,
       orbit_label: "System primary",
-      chart_x: localChartData.star.position_x,
-      chart_y: localChartData.star.position_y,
-      chart_z: localChartData.star.position_z,
+      chart_x: starWorldPosition?.x ?? localChartData.star.position_x,
+      chart_y: starWorldPosition?.y ?? localChartData.star.position_y,
+      chart_z: starWorldPosition?.z ?? localChartData.star.position_z,
     });
 
     localChartData.planets.forEach((planet) => {
       const planetId = `planet-${planet.id}`;
+      const planetWorldPosition = scannerContactWorldPositionById.get(planetId);
       rows.push({
         id: planetId,
         contact_type: "planet",
@@ -4392,15 +4713,16 @@ export default function Home() {
         radius_km: planet.radius_km,
         distance_km: scannerContactById.get(planetId)?.distance_km ?? null,
         orbit_label: `${planet.orbit_radius_km.toLocaleString()} km`,
-        chart_x: planet.position_x,
-        chart_y: planet.position_y,
-        chart_z: planet.position_z,
+        chart_x: planetWorldPosition?.x ?? planet.position_x,
+        chart_y: planetWorldPosition?.y ?? planet.position_y,
+        chart_z: planetWorldPosition?.z ?? planet.position_z,
       });
     });
 
     Object.values(localChartData.moons_by_parent_body_id).forEach((moons) => {
       moons.forEach((moon) => {
         const moonId = `moon-${moon.id}`;
+        const moonWorldPosition = scannerContactWorldPositionById.get(moonId);
         const parentLabel = moon.parent_body_id
           ? (planetNameById.get(moon.parent_body_id) ?? `Body #${moon.parent_body_id}`)
           : "Parent unknown";
@@ -4414,9 +4736,9 @@ export default function Home() {
           radius_km: moon.radius_km,
           distance_km: scannerContactById.get(moonId)?.distance_km ?? null,
           orbit_label: `${moon.orbit_radius_km.toLocaleString()} km · ${parentLabel}`,
-          chart_x: moon.position_x,
-          chart_y: moon.position_y,
-          chart_z: moon.position_z,
+          chart_x: moonWorldPosition?.x ?? moon.position_x,
+          chart_y: moonWorldPosition?.y ?? moon.position_y,
+          chart_z: moonWorldPosition?.z ?? moon.position_z,
         });
       });
     });
@@ -4424,6 +4746,7 @@ export default function Home() {
     localChartData.stations.forEach((station) => {
       const stationId = `station-${station.id}`;
       const stationContact = scannerContactById.get(stationId);
+      const stationWorldPosition = scannerContactWorldPositionById.get(stationId);
       rows.push({
         id: stationId,
         contact_type: "station",
@@ -4436,28 +4759,32 @@ export default function Home() {
         orbit_label: station.host_body_id
           ? (planetNameById.get(station.host_body_id) ?? `Body #${station.host_body_id}`)
           : "—",
-        chart_x: station.position_x,
-        chart_y: station.position_y,
-        chart_z: station.position_z,
+        chart_x: stationWorldPosition?.x ?? station.position_x,
+        chart_y: stationWorldPosition?.y ?? station.position_y,
+        chart_z: stationWorldPosition?.z ?? station.position_z,
       });
     });
 
     const shipRows = scannerContacts
       .filter((contact) => contact.contact_type === "ship")
-      .map((contact) => ({
-        id: contact.id,
-        contact_type: "ship" as const,
-        body_kind: "ship" as const,
-        body_type: null,
-        name: contact.name,
-        visual_label: contact.ship_visual_key ?? "cobra-mk1",
-        radius_km: null,
-        distance_km: contact.distance_km,
-        orbit_label: contact.orbiting_planet_name ?? "—",
-        chart_x: contact.scene_x,
-        chart_y: contact.scene_y,
-        chart_z: contact.scene_z,
-      }))
+      .map((contact) => {
+        const worldPosition = scannerContactWorldPositionById.get(contact.id)
+          ?? resolveFallbackChartPosition(contact);
+        return {
+          id: contact.id,
+          contact_type: "ship" as const,
+          body_kind: "ship" as const,
+          body_type: null,
+          name: contact.name,
+          visual_label: contact.ship_visual_key ?? "cobra-mk1",
+          radius_km: null,
+          distance_km: contact.distance_km,
+          orbit_label: contact.orbiting_planet_name ?? "—",
+          chart_x: worldPosition.x,
+          chart_y: worldPosition.y,
+          chart_z: worldPosition.z,
+        };
+      })
       .sort((left, right) => {
         const distanceDelta = (left.distance_km ?? Number.POSITIVE_INFINITY)
           - (right.distance_km ?? Number.POSITIVE_INFINITY);
@@ -4487,7 +4814,15 @@ export default function Home() {
       ...ordered,
       ...Array.from({ length: minimumRows - ordered.length }, () => null),
     ];
-  }, [localChartData, localChartLayers, scannerContacts]);
+  }, [
+    flightDockingApproachTargetContactId,
+    jumpTargetStationId,
+    localChartData,
+    localChartLayers,
+    scannerContacts,
+    scannerLiveContacts,
+    scannerSelectedContactId,
+  ]);
 
   const localChartDisplayResult = useMemo<{
     rows: (LocalChartRow | null)[];
@@ -5021,14 +5356,14 @@ export default function Home() {
     if (flightDockingApproachTargetContactId) {
       return flightDockingApproachTargetContactId;
     }
+    if (flightLocalWaypointContactId) {
+      return flightLocalWaypointContactId;
+    }
     if (flightDestinationLockedContactId) {
       return flightDestinationLockedContactId;
     }
     if (flightDestinationLockedId) {
       return `station-${flightDestinationLockedId}`;
-    }
-    if (flightLocalWaypointContactId) {
-      return flightLocalWaypointContactId;
     }
     if (scannerSelectedContactId) {
       return scannerSelectedContactId;
@@ -6404,6 +6739,9 @@ export default function Home() {
     if (flightDockingApproachTargetContactId) {
       return flightDockingApproachTargetContactId;
     }
+    if (flightLocalWaypointContactId) {
+      return flightLocalWaypointContactId;
+    }
     if (flightDestinationLockedContactId) {
       return flightDestinationLockedContactId;
     }
@@ -6411,7 +6749,12 @@ export default function Home() {
       return null;
     }
     return `station-${flightDestinationLockedId}`;
-  }, [flightDestinationLockedContactId, flightDockingApproachTargetContactId, flightDestinationLockedId]);
+  }, [
+    flightDestinationLockedContactId,
+    flightDestinationLockedId,
+    flightDockingApproachTargetContactId,
+    flightLocalWaypointContactId,
+  ]);
 
   const scannerLiveContactMap = useMemo(() => {
     const map = new Map<string, ScannerLiveContact>();
@@ -6433,31 +6776,89 @@ export default function Home() {
       localChartData.stations.map((station) => [station.id, station]),
     );
 
-    for (const liveContact of scannerLiveContacts) {
+    const preferredStationContactIds: string[] = [];
+    if (flightDockingApproachTargetContactId?.startsWith("station-")) {
+      preferredStationContactIds.push(flightDockingApproachTargetContactId);
+    }
+    if (scannerSelectedContactId?.startsWith("station-")) {
+      preferredStationContactIds.push(scannerSelectedContactId);
+    }
+    if (jumpTargetStationId && Number.isInteger(jumpTargetStationId) && jumpTargetStationId > 0) {
+      preferredStationContactIds.push(`station-${jumpTargetStationId}`);
+    }
+
+    const liveStationContactById = new Map(
+      scannerLiveContacts.map((liveContact) => [liveContact.id, liveContact]),
+    );
+
+    const resolveAnchoredPosition = (liveContact: ScannerLiveContact | undefined): {
+      x: number;
+      y: number;
+      z: number;
+    } | null => {
+      if (!liveContact) {
+        return null;
+      }
+
       const scannerContact = scannerContactById.get(liveContact.id);
       if (!scannerContact || scannerContact.contact_type !== "station") {
-        continue;
+        return null;
       }
 
       const stationId = parseStationContactId(scannerContact.id);
       if (!stationId) {
-        continue;
+        return null;
       }
 
       const station = stationById.get(stationId);
       if (!station) {
-        continue;
+        return null;
       }
 
       return {
-        x: station.position_x - (liveContact.relative_x * STATION_SCENE_TO_WORLD_SCALE_XZ),
-        y: station.position_y - (liveContact.relative_y * STATION_SCENE_TO_WORLD_SCALE_Y),
-        z: station.position_z - (liveContact.relative_z * STATION_SCENE_TO_WORLD_SCALE_XZ),
+        x: station.position_x - (
+          Number.isFinite(liveContact.relative_x_km)
+            ? Number(liveContact.relative_x_km)
+            : liveContact.relative_x * STATION_SCENE_TO_WORLD_SCALE_XZ
+        ),
+        y: station.position_y - (
+          Number.isFinite(liveContact.relative_y_km)
+            ? Number(liveContact.relative_y_km)
+            : liveContact.relative_y * STATION_SCENE_TO_WORLD_SCALE_Y
+        ),
+        z: station.position_z - (
+          Number.isFinite(liveContact.relative_z_km)
+            ? Number(liveContact.relative_z_km)
+            : liveContact.relative_z * STATION_SCENE_TO_WORLD_SCALE_XZ
+        ),
       };
+    };
+
+    for (const preferredContactId of preferredStationContactIds) {
+      const anchoredPosition = resolveAnchoredPosition(
+        liveStationContactById.get(preferredContactId),
+      );
+      if (anchoredPosition) {
+        return anchoredPosition;
+      }
     }
 
-    return null;
-  }, [localChartData?.stations, scannerContacts, scannerLiveContacts]);
+    const nearestLiveStationContact = scannerLiveContacts
+      .filter((liveContact) => {
+        const scannerContact = scannerContactById.get(liveContact.id);
+        return scannerContact?.contact_type === "station";
+      })
+      .sort((left, right) => left.distance - right.distance)[0];
+
+    return resolveAnchoredPosition(nearestLiveStationContact);
+  }, [
+    flightDockingApproachTargetContactId,
+    jumpTargetStationId,
+    localChartData?.stations,
+    scannerContacts,
+    scannerLiveContacts,
+    scannerSelectedContactId,
+  ]);
 
   const activeDockTargetLiveContact = useMemo(() => {
     if (!activeDockTargetContact) {
@@ -6506,6 +6907,19 @@ export default function Home() {
     }
     return activeDockTargetDistanceKm <= dockingComputerRangeKm;
   }, [activeDockTargetDistanceKm, dockingComputerRangeKm]);
+
+  const isDockingRotationMatchEnabled = useMemo(() => {
+    return (
+      isDockingApproachActive
+      && activeDockTargetDistanceMode === "port"
+      && activeDockTargetDistanceKm !== null
+      && activeDockTargetDistanceKm <= 2
+    );
+  }, [
+    activeDockTargetDistanceKm,
+    activeDockTargetDistanceMode,
+    isDockingApproachActive,
+  ]);
 
   const dockTargetRangeLabel = useMemo(() => {
     if (!activeDockTargetContact) {
@@ -6603,6 +7017,15 @@ export default function Home() {
       const scannerAltitudeRangeKm = Math.max(10, scannerPlaneRangeKm * 0.44);
       const live = scannerLiveContactMap.get(contact.id);
       const isInView = live?.in_view ?? true;
+      const fallbackRelativeX = Number.isFinite(contact.relative_x_km)
+        ? Number(contact.relative_x_km)
+        : contact.scene_x;
+      const fallbackRelativeY = Number.isFinite(contact.relative_y_km)
+        ? Number(contact.relative_y_km)
+        : contact.scene_y;
+      const fallbackRelativeZ = Number.isFinite(contact.relative_z_km)
+        ? Number(contact.relative_z_km)
+        : contact.scene_z;
 
       const effectiveDistanceKm = resolveScannerDisplayDistanceKm(
         contact.distance_km,
@@ -6610,19 +7033,13 @@ export default function Home() {
       );
       const isBeyondScannerRange = effectiveDistanceKm > scannerRangeKm;
 
-      const fallbackPlaneX = Math.max(-1, Math.min(1, contact.scene_x / scannerPlaneRangeKm));
-      const fallbackPlaneY = Math.max(-1, Math.min(1, (-contact.scene_z) / scannerPlaneRangeKm));
-      const fallbackAltitude = Math.max(-1, Math.min(1, contact.scene_y / scannerAltitudeRangeKm));
+      const fallbackPlaneX = Math.max(-1, Math.min(1, fallbackRelativeX / scannerPlaneRangeKm));
+      const fallbackPlaneY = Math.max(-1, Math.min(1, (-fallbackRelativeZ) / scannerPlaneRangeKm));
+      const fallbackAltitude = Math.max(-1, Math.min(1, fallbackRelativeY / scannerAltitudeRangeKm));
 
-      const rawPlaneX = live
-        ? (isInView ? Math.max(-1, Math.min(1, live.fov_x)) : live.plane_x)
-        : fallbackPlaneX;
-      const rawPlaneY = live
-        ? (isInView ? Math.max(-1, Math.min(1, live.fov_y)) : live.plane_y)
-        : fallbackPlaneY;
-      const rawAltitude = live
-        ? (isInView ? 0 : live.altitude)
-        : fallbackAltitude;
+      const rawPlaneX = live ? live.plane_x : fallbackPlaneX;
+      const rawPlaneY = live ? live.plane_y : fallbackPlaneY;
+      const rawAltitude = live ? live.altitude : fallbackAltitude;
 
       const visibleOnScannerGrid = (
         !isBeyondScannerRange
@@ -6630,7 +7047,6 @@ export default function Home() {
           ? (
             Math.abs(rawPlaneX) <= 1
             && Math.abs(rawPlaneY) <= 1
-            && Math.abs(rawAltitude) <= 1
           )
           : true)
       );
@@ -6644,8 +7060,6 @@ export default function Home() {
       const SCANNER_X_RANGE_PERCENT = 42;
       const SCANNER_Y_RANGE_PERCENT = 39;
       const SCANNER_ALTITUDE_RANGE_PERCENT = 18;
-      const SCANNER_DISTANCE_NEAR_KM = 4;
-      const SCANNER_DISTANCE_FAR_KM = Math.max(SCANNER_DISTANCE_NEAR_KM + 1, scannerRangeKm);
       const SCANNER_PLANE_TOP_PERCENT = 44;
       const SCANNER_PLANE_BOTTOM_PERCENT = 88;
       const SCANNER_PLANE_CENTER_Y_PERCENT =
@@ -6655,16 +7069,6 @@ export default function Home() {
       const SCANNER_PLANE_VISUAL_PADDING_PERCENT = 2.2;
 
       const planeTop = (() => {
-        if (live && isInView) {
-          const normalizedDistance = Math.max(0, Math.min(
-            1,
-            (effectiveDistanceKm - SCANNER_DISTANCE_NEAR_KM)
-            / (SCANNER_DISTANCE_FAR_KM - SCANNER_DISTANCE_NEAR_KM),
-          ));
-          const distanceDepthFactor = Math.sqrt(normalizedDistance);
-          return clampPercent(SCANNER_CENTER_PERCENT - (distanceDepthFactor * 30));
-        }
-
         const rawPlaneTop = clampPercent(SCANNER_CENTER_PERCENT - (planeY * SCANNER_Y_RANGE_PERCENT));
         const planeEllipseVerticalFactor = Math.sqrt(
           Math.max(0, 1 - (planeX * planeX)),
@@ -6687,18 +7091,7 @@ export default function Home() {
         );
       })();
 
-      const left = (() => {
-        if (live && isInView) {
-          const dyFromOrigin = Math.max(0, SCANNER_CENTER_PERCENT - planeTop);
-          const halfAngleRadians = (scannerFovHalfAngleDegrees * Math.PI) / 180;
-          const wedgeHalfWidth = Math.max(
-            2,
-            dyFromOrigin * Math.tan(halfAngleRadians),
-          );
-          return clampPercent(50 + (planeX * wedgeHalfWidth));
-        }
-        return clampPercent(SCANNER_CENTER_PERCENT + planeX * SCANNER_X_RANGE_PERCENT);
-      })();
+      const left = clampPercent(SCANNER_CENTER_PERCENT + planeX * SCANNER_X_RANGE_PERCENT);
 
       const dotTop = live && isInView
         ? planeTop
@@ -6712,9 +7105,9 @@ export default function Home() {
         altitude,
         inView: isInView,
         isBeyondScannerRange,
-        relativeX: live?.relative_x ?? contact.scene_x,
-        relativeY: live?.relative_y ?? contact.scene_y,
-        relativeZ: live?.relative_z ?? contact.scene_z,
+        relativeX: live?.relative_x ?? fallbackRelativeX,
+        relativeY: live?.relative_y ?? fallbackRelativeY,
+        relativeZ: live?.relative_z ?? fallbackRelativeZ,
         displayDistance: effectiveDistanceKm,
         visibleOnScannerGrid,
         planeX,
@@ -6726,7 +7119,7 @@ export default function Home() {
         scannerTop: planeTop,
       };
     })
-  ), [scannerContacts, scannerFovHalfAngleDegrees, scannerLiveContactMap, scannerRangeKm]);
+  ), [scannerContacts, scannerLiveContactMap, scannerRangeKm]);
 
   const scannerOutOfRangeContactCount = useMemo(
     () => scannerHudContacts.filter((contact) => contact.isBeyondScannerRange).length,
@@ -6754,7 +7147,7 @@ export default function Home() {
     ];
   }, [scannerHudContacts, scannerSelectedContactId]);
 
-  const scannerCelestialAnchors = useMemo(
+  const scannerCelestialAnchors = useMemo<FlightSceneCelestialAnchor[]>(
     () => {
       if (localChartData) {
         return buildFlightCelestialAnchors(localChartData, scannerContacts).slice(0, 24);
@@ -6766,7 +7159,28 @@ export default function Home() {
           || contact.contact_type === "planet"
           || contact.contact_type === "moon"
         ))
-        .slice(0, 10);
+        .slice(0, 10)
+        .map((contact) => ({
+          id: contact.id,
+          contact_type: contact.contact_type,
+          name: contact.name,
+          distance_km: contact.distance_km,
+          orbiting_planet_name: contact.orbiting_planet_name ?? null,
+          body_kind: contact.body_kind
+            ?? (contact.contact_type === "star"
+              ? "star"
+              : contact.contact_type === "moon"
+                ? "moon"
+                : "planet"),
+          body_type: contact.body_type ?? null,
+          radius_km: contact.radius_km ?? null,
+          relative_x_km: contact.relative_x_km,
+          relative_y_km: contact.relative_y_km,
+          relative_z_km: contact.relative_z_km,
+          presentation_x: contact.scene_x,
+          presentation_y: contact.scene_y,
+          presentation_z: contact.scene_z,
+        }));
     },
     [localChartData, scannerContacts],
   );
@@ -7090,17 +7504,23 @@ export default function Home() {
 
   const syncShipPositionDuringFlight = useCallback(async (
     nextPosition: { x: number; y: number; z: number },
-  ): Promise<void> => {
+    options?: { dockingApproachActive?: boolean },
+  ): Promise<ShipTelemetry | null> => {
     if (!token) {
-      return;
+      return null;
     }
 
     const parsedShipId = Number(shipId);
     if (!Number.isInteger(parsedShipId) || parsedShipId <= 0) {
-      return;
+      return null;
     }
 
     try {
+      if (options?.dockingApproachActive) {
+        emitDockingDebugLog("position-sync.request", {
+          nextPosition,
+        });
+      }
       const response = await fetch(`${API_BASE}/api/ships/${parsedShipId}/position-sync`, {
         method: "POST",
         headers: {
@@ -7114,22 +7534,45 @@ export default function Home() {
         }),
       });
       if (!response.ok) {
-        return;
+        if (options?.dockingApproachActive) {
+          emitDockingDebugLog("position-sync.non-200", {
+            status: response.status,
+          });
+        }
+        return null;
       }
 
       const data = await response.json();
-      setShipTelemetry(data);
+      const typedTelemetry = data as ShipTelemetry;
+      if (options?.dockingApproachActive) {
+        emitDockingDebugLog("position-sync.ok", {
+          syncedPosition: {
+            x: typedTelemetry.position_x ?? null,
+            y: typedTelemetry.position_y ?? null,
+            z: typedTelemetry.position_z ?? null,
+          },
+        });
+      }
+      setShipTelemetry(typedTelemetry);
       flightPositionSyncLastCoordsRef.current = nextPosition;
 
       const now = Date.now();
-      if (now - flightPositionSyncLastScannerRefreshAtRef.current >= 1500) {
+      if (
+        !options?.dockingApproachActive
+        && now - flightPositionSyncLastScannerRefreshAtRef.current >= 1500
+      ) {
         flightPositionSyncLastScannerRefreshAtRef.current = now;
         void fetchScannerContacts({ silent: true });
       }
+      return typedTelemetry;
     } catch {
-      return;
+      if (options?.dockingApproachActive) {
+        emitDockingDebugLog("position-sync.error");
+      }
+      return null;
     }
   }, [
+    emitDockingDebugLog,
     fetchScannerContacts,
     shipId,
     token,
@@ -7260,6 +7703,8 @@ export default function Home() {
         ? "safe hold-point maneuver"
         : stage === "hold-align"
           ? "hold-point alignment"
+          : stage === "tunnel-entry"
+            ? "tunnel entry"
           : "final docking approach";
       setShipOpsStatus(
         `Docking approach to ${targetName}: ${stageLabel} · ${distanceKm.toFixed(1)} km (${normalizedProgress.toFixed(0)}%).`,
@@ -7267,6 +7712,12 @@ export default function Home() {
     },
     [flightJumpProgress, isDockingApproachActive],
   );
+
+  const handleFlightSceneDockingDebug = useCallback((
+    payload: FlightDockingDebugPayload,
+  ): void => {
+    emitDockingDebugLog(`scene.${payload.event}`, payload);
+  }, [emitDockingDebugLog]);
 
   const handleFlightDockingApproachComplete = useCallback(async (): Promise<void> => {
     const stationId = flightDockingApproachTargetStationId;
@@ -7279,9 +7730,36 @@ export default function Home() {
     dockingApproachCompletionInFlightRef.current = true;
     setFlightJumpProgress(100);
     setShipOpsStatus("Final approach complete. Requesting docking clamps...");
+    const finalDockingPosition = liveStationAnchoredShipPosition
+      ? {
+        x: Math.round(liveStationAnchoredShipPosition.x),
+        y: Math.round(liveStationAnchoredShipPosition.y),
+        z: Math.round(liveStationAnchoredShipPosition.z),
+      }
+      : null;
+    if (finalDockingPosition) {
+      emitDockingDebugLog("dock-request.pre-sync", {
+        stationId,
+        stationLabel,
+        finalDockingPosition,
+      });
+      await syncShipPositionDuringFlight(finalDockingPosition, {
+        dockingApproachActive: true,
+      });
+    }
+    emitDockingDebugLog("dock-request.dispatch", {
+      stationId,
+      stationLabel,
+    });
 
     const success = await handleShipOperation("dock", {
       stationIdOverride: stationId,
+    });
+
+    emitDockingDebugLog("dock-request.result", {
+      stationId,
+      stationLabel,
+      success,
     });
 
     resetDockingApproachState();
@@ -7300,12 +7778,15 @@ export default function Home() {
     void persistFlightState(FLIGHT_PHASE.ERROR, null);
   }, [
     activeDockTargetContact?.name,
+    emitDockingDebugLog,
     dispatchFlightAudioEvent,
     flightDockingApproachTargetStationId,
     handleShipOperation,
+    liveStationAnchoredShipPosition,
     persistFlightState,
     resetDockingApproachState,
     runDockInboundTransitCinematic,
+    syncShipPositionDuringFlight,
   ]);
 
   const handleCancelDockingApproach = useCallback((): void => {
@@ -7331,6 +7812,9 @@ export default function Home() {
 
   const handleDockCommand = useCallback(
     async (stationIdOverride?: number): Promise<void> => {
+      emitDockingDebugLog("dock-command", {
+        stationIdOverride: stationIdOverride ?? null,
+      });
       if (isDockingApproachActive) {
         setShipOpsStatus("Docking approach already in progress.");
         return;
@@ -7346,6 +7830,10 @@ export default function Home() {
       const targetContact = scannerContacts.find((contact) => contact.id === targetContactId);
 
       if (!targetContact) {
+        emitDockingDebugLog("dock-command.target-sync", {
+          stationId: parsedDockStationId,
+          targetContactId,
+        });
         setActiveMode("flight");
         setFlightJumpPhase(FLIGHT_PHASE.DOCKING_APPROACH);
         setFlightJumpProgress(0);
@@ -7360,6 +7848,13 @@ export default function Home() {
         return;
       }
 
+      emitDockingDebugLog("dock-command.approach-start", {
+        stationId: parsedDockStationId,
+        targetContactId,
+        targetName: targetContact.name,
+        targetDistanceKm: targetContact.distance_km,
+      });
+
       setActiveMode("flight");
       setFlightJumpPhase(FLIGHT_PHASE.DOCKING_APPROACH);
       setFlightJumpProgress(0);
@@ -7373,6 +7868,7 @@ export default function Home() {
       void persistFlightState(FLIGHT_PHASE.DOCKING_APPROACH, parsedDockStationId);
     },
     [
+      emitDockingDebugLog,
       dispatchFlightAudioEvent,
       dockStationId,
       isDockingApproachActive,
@@ -8166,12 +8662,13 @@ export default function Home() {
       }
 
       const payload = data as CollisionCheckResponse;
-      setShipTelemetry(payload.ship);
+      setShipTelemetry(mergeCollisionTelemetryShip(payload));
       syncJumpCooldownFromShipTelemetry(payload.ship);
       syncFlightStateFromShipTelemetry(payload.ship);
       setFlightCollisionStatus(sanitizeCollisionStatusMessage(payload.message));
 
       if (payload.collision) {
+        dispatchCollisionAudioEvents(payload);
         const signature = `${payload.severity}:${payload.object_id ?? "unknown"}:${payload.recovered ? "r" : "n"}`;
         const severityLabel = payload.severity.toUpperCase();
         const objectLabel = payload.object_name ?? payload.object_type ?? "unknown object";
@@ -8208,9 +8705,6 @@ export default function Home() {
       }
 
       if (payload.recovered) {
-        dispatchFlightAudioEvent("ops.crash_recovery_complete", {
-          object_id: payload.object_id ?? null,
-        });
         setFlightSceneResetKey((current) => current + 1);
         await fetchScannerContacts({ silent: true });
       }
@@ -8224,7 +8718,8 @@ export default function Home() {
     flightCollisionStatus,
     isFlightTransitActive,
     isDockingApproachActive,
-    dispatchFlightAudioEvent,
+    dispatchCollisionAudioEvents,
+    mergeCollisionTelemetryShip,
     shipId,
     showToast,
     syncFlightStateFromShipTelemetry,
@@ -8359,6 +8854,13 @@ export default function Home() {
       JSON.stringify(localChartSortState),
     );
   }, [localChartSortState]);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      FLIGHT_CAMERA_MODE_STORAGE_KEY,
+      flightCameraMode,
+    );
+  }, [flightCameraMode]);
 
   useEffect(() => {
     window.localStorage.setItem(
@@ -8959,7 +9461,7 @@ export default function Home() {
     if (!jumpPhaseIsStable) {
       return;
     }
-    if (isFlightTransitActive || isDockingApproachActive || !liveStationAnchoredShipPosition) {
+    if (isFlightTransitActive || !liveStationAnchoredShipPosition) {
       return;
     }
 
@@ -8969,18 +9471,20 @@ export default function Home() {
       z: Math.round(liveStationAnchoredShipPosition.z),
     };
     const lastPosition = flightPositionSyncLastCoordsRef.current;
+    const minimumAxisDelta = 2;
     const movedEnough = (
       lastPosition === null
-      || Math.abs(roundedPosition.x - lastPosition.x) >= 2
-      || Math.abs(roundedPosition.y - lastPosition.y) >= 2
-      || Math.abs(roundedPosition.z - lastPosition.z) >= 2
+      || Math.abs(roundedPosition.x - lastPosition.x) >= minimumAxisDelta
+      || Math.abs(roundedPosition.y - lastPosition.y) >= minimumAxisDelta
+      || Math.abs(roundedPosition.z - lastPosition.z) >= minimumAxisDelta
     );
     if (!movedEnough) {
       return;
     }
 
     const now = Date.now();
-    if (now - flightPositionSyncLastSentAtRef.current < 900) {
+    const syncIntervalMs = isDockingApproachActive ? 1200 : 900;
+    if (now - flightPositionSyncLastSentAtRef.current < syncIntervalMs) {
       return;
     }
     if (flightPositionSyncInFlightRef.current) {
@@ -8989,7 +9493,9 @@ export default function Home() {
 
     flightPositionSyncInFlightRef.current = true;
     flightPositionSyncLastSentAtRef.current = now;
-    void syncShipPositionDuringFlight(roundedPosition).finally(() => {
+    void syncShipPositionDuringFlight(roundedPosition, {
+      dockingApproachActive: isDockingApproachActive,
+    }).finally(() => {
       flightPositionSyncInFlightRef.current = false;
     });
   }, [
@@ -9056,12 +9562,21 @@ export default function Home() {
       setFlightCollisionStatus("Transit safety corridor active.");
       return;
     }
-    if (isDockingApproachActive) {
+    const dockingPhaseActive = (
+      isDockingApproachActive
+      || flightJumpPhase === FLIGHT_PHASE.DOCKING_APPROACH
+    );
+    if (dockingPhaseActive) {
       setFlightCollisionStatus("Docking computer safety corridor active.");
       return;
     }
     if (shipTelemetry?.status !== "in-space") {
       setFlightCollisionStatus("Collision checks active only while in-space");
+      return;
+    }
+
+    if (Math.abs(flightSpeedUnits) > 0.35) {
+      setFlightCollisionStatus("Collision monitor hold while maneuvering.");
       return;
     }
 
@@ -9076,130 +9591,12 @@ export default function Home() {
   }, [
     activeMode,
     fetchCollisionTelemetry,
+    flightJumpPhase,
+    flightSpeedUnits,
     isDockingApproachActive,
     isFlightTransitActive,
     shipTelemetry?.status,
     token,
-  ]);
-
-  useEffect(() => {
-    if (
-      isDockingApproachActive
-      || isFlightTransitActive
-      || activeMode !== "flight"
-      || shipTelemetry?.status !== "in-space"
-      || isSafetyCorridorCollisionStatus(flightCollisionStatus)
-    ) {
-      activeProximityCollisionContactIdRef.current = null;
-      return;
-    }
-
-    const contactById = new Map(scannerContacts.map((contact) => [contact.id, contact]));
-    const thresholdByType: Record<ScannerContactType, number> = {
-      ship: 1.1,
-      station: 1.6,
-      planet: 1.9,
-      moon: 1.7,
-      star: 2.4,
-    };
-
-    let nearestImpactCandidate: {
-      id: string;
-      type: ScannerContactType;
-      name: string;
-      distance: number;
-      threshold: number;
-    } | null = null;
-
-    scannerLiveContacts.forEach((liveContact) => {
-      const scannerContact = contactById.get(liveContact.id);
-      if (!scannerContact) {
-        return;
-      }
-      const threshold = thresholdByType[scannerContact.contact_type];
-      if (!Number.isFinite(threshold) || threshold <= 0) {
-        return;
-      }
-
-      if (liveContact.distance > threshold) {
-        return;
-      }
-
-      if (nearestImpactCandidate === null || liveContact.distance < nearestImpactCandidate.distance) {
-        nearestImpactCandidate = {
-          id: scannerContact.id,
-          type: scannerContact.contact_type,
-          name: scannerContact.name,
-          distance: liveContact.distance,
-          threshold,
-        };
-      }
-    });
-
-    if (nearestImpactCandidate === null) {
-      activeProximityCollisionContactIdRef.current = null;
-      return;
-    }
-
-    const impactCandidate = nearestImpactCandidate as {
-      id: string;
-      type: ScannerContactType;
-      name: string;
-      distance: number;
-      threshold: number;
-    };
-
-    if (activeProximityCollisionContactIdRef.current === impactCandidate.id) {
-      return;
-    }
-
-    activeProximityCollisionContactIdRef.current = impactCandidate.id;
-    const localSpeed = Math.abs(flightSpeedUnits);
-    const severity: "glancing" | "critical" = (
-      impactCandidate.type === "station"
-      || impactCandidate.type === "star"
-      || localSpeed >= 3.5
-      || impactCandidate.distance <= Math.max(0.8, impactCandidate.threshold * 0.55)
-    )
-      ? "critical"
-      : "glancing";
-
-    if (impactCandidate.type === "moon") {
-      return;
-    }
-
-    dispatchFlightAudioEvent("collision.warning_alarm", {
-      contact_id: impactCandidate.id,
-      contact_type: impactCandidate.type,
-      distance_km: impactCandidate.distance,
-      severity,
-    });
-    if (impactCandidate.type === "ship") {
-      dispatchFlightAudioEvent("flight.traffic_flyby", {
-        contact_id: impactCandidate.id,
-        distance_km: impactCandidate.distance,
-      });
-    }
-
-    void handleFlightSceneCollision({
-      contactId: impactCandidate.id,
-      contactType: impactCandidate.type,
-      contactName: impactCandidate.name,
-      distance: impactCandidate.distance,
-      speed: localSpeed,
-      severity,
-    });
-  }, [
-    activeMode,
-    dispatchFlightAudioEvent,
-    flightCollisionStatus,
-    flightSpeedUnits,
-    handleFlightSceneCollision,
-    isDockingApproachActive,
-    isFlightTransitActive,
-    scannerContacts,
-    scannerLiveContacts,
-    shipTelemetry?.status,
   ]);
 
   const handleCommsSend = async () => {
@@ -11759,6 +12156,7 @@ export default function Home() {
                             jumpPhase={flightJumpPhase}
                             jumpProgress={flightJumpProgress}
                             renderProfile={flightRenderProfile}
+                            cameraMode={flightCameraMode}
                             shipVisualKey={shipTelemetry?.ship_visual_key || null}
                             stationShapeKey={
                               shipTelemetry?.docked_station_archetype_shape
@@ -11775,6 +12173,7 @@ export default function Home() {
                             onScannerTelemetryChange={setScannerLiveContacts}
                             onCollision={
                               isDockingApproachActive
+                                || flightJumpPhase === FLIGHT_PHASE.DOCKING_APPROACH
                                 || isFlightTransitActive
                                 || isSafetyCorridorCollisionStatus(flightCollisionStatus)
                                 ? undefined
@@ -11784,6 +12183,8 @@ export default function Home() {
                             waypointContactId={flightWaypointContactId}
                             onDockingApproachProgress={handleFlightDockingApproachProgress}
                             onDockingApproachComplete={handleFlightDockingApproachComplete}
+                            onDockingDebug={handleFlightSceneDockingDebug}
+                            dockingRotationMatchEnabled={isDockingRotationMatchEnabled}
                             spawnDirective={flightSpawnDirective}
                             onSpawnDirectiveApplied={(nonce) => {
                               setFlightSpawnDirective((current) => (
@@ -11923,6 +12324,19 @@ export default function Home() {
                           </button>
                           {showFlightSettings ? (
                             <div className={styles.flightSettingsPopover}>
+                              <label>
+                                <span>View Mode</span>
+                                <select
+                                  data-testid="flight-setting-camera-mode"
+                                  value={flightCameraMode}
+                                  onChange={(event) => {
+                                    setFlightCameraMode(event.target.value as FlightCameraMode);
+                                  }}
+                                >
+                                  <option value="boresight">Boresight</option>
+                                  <option value="cockpit">Cockpit</option>
+                                </select>
+                              </label>
                               <label>
                                 <span>Render Profile</span>
                                 <select

--- a/frontend/src/app/scannerDistance.test.ts
+++ b/frontend/src/app/scannerDistance.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import { resolveScannerDisplayDistanceKm } from "./scannerDistance";
 
 describe("resolveScannerDisplayDistanceKm", () => {
-  it("prefers finite live distance when available", () => {
-    expect(resolveScannerDisplayDistanceKm(42, 27)).toBe(27);
+  it("prefers snapshot distance when it is available", () => {
+    expect(resolveScannerDisplayDistanceKm(42, 27)).toBe(42);
   });
 
   it("falls back to snapshot distance when live distance is missing", () => {
@@ -12,11 +12,16 @@ describe("resolveScannerDisplayDistanceKm", () => {
     expect(resolveScannerDisplayDistanceKm(42, undefined)).toBe(42);
   });
 
-  it("clamps negative live distance to zero", () => {
-    expect(resolveScannerDisplayDistanceKm(42, -5)).toBe(0);
+  it("clamps negative live distance to zero when snapshot distance is unavailable", () => {
+    expect(resolveScannerDisplayDistanceKm(0, -5)).toBe(0);
   });
 
-  it("falls back to snapshot when live distance is not finite", () => {
-    expect(resolveScannerDisplayDistanceKm(42, Number.NaN)).toBe(42);
+  it("falls back to live distance when snapshot distance is unavailable", () => {
+    expect(resolveScannerDisplayDistanceKm(0, 27)).toBe(27);
+  });
+
+  it("falls back to zero when neither snapshot nor live distance is usable", () => {
+    expect(resolveScannerDisplayDistanceKm(Number.NaN, Number.NaN)).toBe(0);
+    expect(resolveScannerDisplayDistanceKm(0, Number.NaN)).toBe(0);
   });
 });

--- a/frontend/src/app/scannerDistance.ts
+++ b/frontend/src/app/scannerDistance.ts
@@ -6,6 +6,10 @@ export const resolveScannerDisplayDistanceKm = (
     ? Math.max(0, snapshotDistanceKm)
     : 0;
 
+  if (snapshotDistance > 0) {
+    return snapshotDistance;
+  }
+
   if (liveDistanceKm !== null && liveDistanceKm !== undefined && Number.isFinite(liveDistanceKm)) {
     return Math.max(0, liveDistanceKm);
   }

--- a/frontend/src/components/ui/FlightScene.controls.test.ts
+++ b/frontend/src/components/ui/FlightScene.controls.test.ts
@@ -5,6 +5,7 @@ import {
     advanceManualPitch,
     desiredDockingPitchFromDirection,
     desiredDockingYawFromDirection,
+    projectCameraSpacePointToNdc,
     shortestAngleDelta,
 } from "./FlightScene.math";
 
@@ -70,5 +71,49 @@ describe("FlightScene docking attitude convergence", () => {
         expect(finalYawError).toBeLessThan(initialYawError * 0.25);
         expect(finalPitchError).toBeLessThan(initialPitchError * 0.25);
         expect(pitch).toBeLessThan(0);
+    });
+});
+
+describe("FlightScene docking screen framing math", () => {
+    it("treats a centered point ahead of the camera as visible", () => {
+        const projected = projectCameraSpacePointToNdc({
+            cameraSpaceX: 0,
+            cameraSpaceY: 0,
+            cameraSpaceZ: -10,
+            verticalFovDegrees: 30,
+            aspectRatio: 16 / 9,
+        });
+
+        expect(projected.inFront).toBe(true);
+        expect(projected.inView).toBe(true);
+        expect(projected.ndcX).toBeCloseTo(0, 6);
+        expect(projected.ndcY).toBeCloseTo(0, 6);
+    });
+
+    it("rejects a point outside the frustum bounds", () => {
+        const projected = projectCameraSpacePointToNdc({
+            cameraSpaceX: 6,
+            cameraSpaceY: 0,
+            cameraSpaceZ: -4,
+            verticalFovDegrees: 30,
+            aspectRatio: 16 / 9,
+        });
+
+        expect(projected.inFront).toBe(true);
+        expect(projected.inView).toBe(false);
+        expect(projected.ndcX).toBeGreaterThan(1);
+    });
+
+    it("rejects a point behind the camera", () => {
+        const projected = projectCameraSpacePointToNdc({
+            cameraSpaceX: 0,
+            cameraSpaceY: 0,
+            cameraSpaceZ: 2,
+            verticalFovDegrees: 30,
+            aspectRatio: 16 / 9,
+        });
+
+        expect(projected.inFront).toBe(false);
+        expect(projected.inView).toBe(false);
     });
 });

--- a/frontend/src/components/ui/FlightScene.docking.test.ts
+++ b/frontend/src/components/ui/FlightScene.docking.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    calculateDockingCameraPresentationBlend,
+    calculateDockingScreenValidity,
+    resolveDockingCompletionWindow,
+    resolveDockingRotationMatch,
+    resolveDockingStageTransition,
+} from "./FlightScene.docking";
+
+const transitionConfig = {
+    holdPointThresholdKm: 0.42,
+    holdEntryMinDurationMs: 2600,
+    holdEntryAlignCosine: Math.cos((36 * Math.PI) / 180),
+    holdEntryCorridorToleranceKm: 0.18,
+    holdAlignRequiredCosine: Math.cos((8 * Math.PI) / 180),
+    holdAlignCorridorToleranceKm: 0.22,
+    holdAlignDurationMs: 900,
+    holdAlignStableMs: 650,
+    holdAlignMaxDurationMs: 9000,
+    holdAlignTimeoutRequiredCosine: Math.cos((14 * Math.PI) / 180),
+    holdAlignTimeoutCorridorToleranceKm: 0.34,
+    holdAlignTimeoutMaxDistanceKm: 1.15,
+    holdAlignFinalEntryMaxDistanceKm: 0.82,
+    holdAlignResetAlignmentCosine: Math.cos((58 * Math.PI) / 180),
+    holdAlignResetCorridorMinKm: 0.16,
+    holdAlignResetTimeoutMs: 4200,
+    holdAlignResetCooldownMs: 2200,
+    tunnelEntryMinDurationMs: 550,
+    tunnelEntryFinalTriggerKm: 0.18,
+    finalHardLockAlignmentCosine: Math.cos((10 * Math.PI) / 180),
+    finalInsidePortCorridorMaxKm: 0.05,
+    finalReacquireMinElapsedMs: 850,
+    finalReacquireCooldownMs: 1600,
+    finalReacquireMinDistanceKm: 0.2,
+    finalReacquireAlignmentCosine: Math.cos((68 * Math.PI) / 180),
+    finalReacquireCorridorMinKm: 0.18,
+};
+
+const completionConfig = {
+    finalHardLockThresholdKm: 0.14,
+    completeMinTunnelPenetrationKm: 0.32,
+    finalHardLockAlignmentCosine: Math.cos((10 * Math.PI) / 180),
+    finalInsidePortCorridorMaxKm: 0.05,
+    finalInsidePortMaxSpeed: 0.05,
+    finalInsidePortThresholdKm: 0.11,
+    completeStrictTunnelPenetrationKm: 0.36,
+    finalInsidePortApproachMaxKm: 0.09,
+    finalNearPortThresholdKm: 0.115,
+    finalNearPortApproachMaxKm: 0.055,
+    finalNearPortCorridorMaxKm: 0.03,
+    finalNearPortMaxSpeed: 0.04,
+    finalStageMinDurationMs: 4200,
+    portThresholdKm: 0.28,
+    directPortAlignmentCosine: Math.cos((4 * Math.PI) / 180),
+    directPortCorridorMaxKm: 0.026,
+    directPortApproachMaxKm: 0.062,
+    directPortMaxSpeed: 0.05,
+    finalStageForceCompleteMs: 12000,
+    portFallbackThresholdKm: 0.48,
+    fallbackAlignmentCosine: Math.cos((20 * Math.PI) / 180),
+    fallbackCorridorMaxKm: 0.11,
+};
+
+const rotationMatchConfig = {
+    rotationMatchMaxDistanceKm: 2,
+    rotationMatchFinalDistanceKm: 0.24,
+    rotationMatchHoldAlignAlignmentCosine: Math.cos((70 * Math.PI) / 180),
+    rotationMatchFinalAlignmentCosine: Math.cos((28 * Math.PI) / 180),
+    rotationMatchHoldAlignCorridorMaxKm: 0.34,
+    rotationMatchFinalCorridorMaxKm: 0.08,
+    rotationMatchReleaseAlignmentCosine: Math.cos((56 * Math.PI) / 180),
+    rotationMatchReleaseCorridorMaxKm: 0.14,
+    rotationMatchReleaseFinalCorridorMaxKm: 0.1,
+};
+
+describe("FlightScene docking helpers", () => {
+    it("calculates boresight presentation blend by stage", () => {
+        expect(calculateDockingCameraPresentationBlend({
+            stage: "hold-entry",
+            distanceToPortKm: 0.3,
+            presentationRangeKm: 1.4,
+        })).toBe(0);
+
+        expect(calculateDockingCameraPresentationBlend({
+            stage: "hold-align",
+            distanceToPortKm: 0.7,
+            presentationRangeKm: 1.4,
+        })).toBeCloseTo(0.225, 6);
+
+        expect(calculateDockingCameraPresentationBlend({
+            stage: "final-approach",
+            distanceToPortKm: 0.35,
+            presentationRangeKm: 1.4,
+        })).toBeCloseTo(0.75, 6);
+    });
+
+    it("derives centered and strict screen validity from projected NDC", () => {
+        expect(calculateDockingScreenValidity({
+            ndcX: 0.4,
+            ndcY: 0.3,
+            inView: true,
+            centerMaxX: 0.72,
+            centerMaxY: 0.66,
+            strictCenterMaxX: 0.52,
+            strictCenterMaxY: 0.48,
+        })).toEqual({
+            portVisibleOnScreen: true,
+            portCenteredOnScreen: true,
+            portStrictlyCenteredOnScreen: true,
+        });
+
+        expect(calculateDockingScreenValidity({
+            ndcX: 0.7,
+            ndcY: 0.1,
+            inView: true,
+            centerMaxX: 0.72,
+            centerMaxY: 0.66,
+            strictCenterMaxX: 0.52,
+            strictCenterMaxY: 0.48,
+        }).portStrictlyCenteredOnScreen).toBe(false);
+    });
+
+    it("transitions from hold-entry to hold-align when corridor and attitude are valid", () => {
+        const transition = resolveDockingStageTransition({
+            stage: "hold-entry",
+            nowMs: 3000,
+            stageStartedAtMs: 0,
+            holdAlignAlignedSinceMs: 0,
+            lastResetAtMs: 0,
+            lastFinalReacquireAtMs: 0,
+            holdEntryDistanceRemainingKm: 0.3,
+            distanceToPortKm: 1.5,
+            distanceToApproachPointKm: 0.4,
+            stageDistanceRemainingKm: 0.3,
+            reticleAlignmentCosine: 0.9,
+            corridorLateralOffsetKm: 0.1,
+            tunnelPenetrationDepthKm: 0,
+            config: transitionConfig,
+        });
+
+        expect(transition).toEqual({
+            nextStage: "hold-align",
+            reason: "hold-entry-threshold-reached",
+        });
+    });
+
+    it("transitions from tunnel-entry to final-approach on sufficient penetration", () => {
+        const transition = resolveDockingStageTransition({
+            stage: "tunnel-entry",
+            nowMs: 1200,
+            stageStartedAtMs: 0,
+            holdAlignAlignedSinceMs: 0,
+            lastResetAtMs: 0,
+            lastFinalReacquireAtMs: 0,
+            holdEntryDistanceRemainingKm: Number.POSITIVE_INFINITY,
+            distanceToPortKm: 0.15,
+            distanceToApproachPointKm: 0.04,
+            stageDistanceRemainingKm: 0.12,
+            reticleAlignmentCosine: 0.99,
+            corridorLateralOffsetKm: 0.02,
+            tunnelPenetrationDepthKm: 0.22,
+            config: transitionConfig,
+        });
+
+        expect(transition).toEqual({
+            nextStage: "final-approach",
+            reason: "tunnel-entry-depth-reached",
+        });
+    });
+
+    it("latches rotation match while release tolerances remain valid", () => {
+        const shouldMatch = resolveDockingRotationMatch({
+            stage: "hold-align",
+            rotationMatchEnabled: true,
+            rotationMatchLatched: true,
+            distanceToPortKm: 0.8,
+            reticleAlignmentCosine: 0.7,
+            corridorLateralOffsetKm: 0.12,
+            config: rotationMatchConfig,
+        });
+
+        expect(shouldMatch).toBe(true);
+    });
+
+    it("rejects completion when the port is not screen-centered", () => {
+        const completion = resolveDockingCompletionWindow({
+            finalApproachElapsedMs: 5000,
+            distanceToPortKm: 0.1,
+            tunnelPenetrationDepthKm: 0.4,
+            reticleAlignmentCosine: 0.999,
+            corridorLateralOffsetKm: 0.01,
+            shipSpeedKmPerSec: 0.03,
+            distanceToApproachPointKm: 0.03,
+            screenValidity: {
+                portVisibleOnScreen: true,
+                portCenteredOnScreen: false,
+                portStrictlyCenteredOnScreen: false,
+            },
+            config: completionConfig,
+        });
+
+        expect(completion).toEqual({
+            completed: false,
+            reason: null,
+        });
+    });
+
+    it("selects the hard-lock completion window when all strict checks pass", () => {
+        const completion = resolveDockingCompletionWindow({
+            finalApproachElapsedMs: 5000,
+            distanceToPortKm: 0.1,
+            tunnelPenetrationDepthKm: 0.35,
+            reticleAlignmentCosine: 0.999,
+            corridorLateralOffsetKm: 0.01,
+            shipSpeedKmPerSec: 0.03,
+            distanceToApproachPointKm: 0.03,
+            screenValidity: {
+                portVisibleOnScreen: true,
+                portCenteredOnScreen: true,
+                portStrictlyCenteredOnScreen: true,
+            },
+            config: completionConfig,
+        });
+
+        expect(completion).toEqual({
+            completed: true,
+            reason: "hard-lock-window",
+        });
+    });
+});

--- a/frontend/src/components/ui/FlightScene.docking.ts
+++ b/frontend/src/components/ui/FlightScene.docking.ts
@@ -1,0 +1,402 @@
+export type DockingApproachStage = "hold-entry" | "hold-align" | "tunnel-entry" | "final-approach";
+
+export type DockingScreenValidity = {
+    portVisibleOnScreen: boolean;
+    portCenteredOnScreen: boolean;
+    portStrictlyCenteredOnScreen: boolean;
+};
+
+export type DockingStageTransition = {
+    nextStage: DockingApproachStage;
+    reason: string;
+};
+
+export type DockingCompletionWindow = {
+    completed: boolean;
+    reason: string | null;
+};
+
+export type DockingTransitionConfig = {
+    holdPointThresholdKm: number;
+    holdEntryMinDurationMs: number;
+    holdEntryAlignCosine: number;
+    holdEntryCorridorToleranceKm: number;
+    holdAlignRequiredCosine: number;
+    holdAlignCorridorToleranceKm: number;
+    holdAlignDurationMs: number;
+    holdAlignStableMs: number;
+    holdAlignMaxDurationMs: number;
+    holdAlignTimeoutRequiredCosine: number;
+    holdAlignTimeoutCorridorToleranceKm: number;
+    holdAlignTimeoutMaxDistanceKm: number;
+    holdAlignFinalEntryMaxDistanceKm: number;
+    holdAlignResetAlignmentCosine: number;
+    holdAlignResetCorridorMinKm: number;
+    holdAlignResetTimeoutMs: number;
+    holdAlignResetCooldownMs: number;
+    tunnelEntryMinDurationMs: number;
+    tunnelEntryFinalTriggerKm: number;
+    finalHardLockAlignmentCosine: number;
+    finalInsidePortCorridorMaxKm: number;
+    finalReacquireMinElapsedMs: number;
+    finalReacquireCooldownMs: number;
+    finalReacquireMinDistanceKm: number;
+    finalReacquireAlignmentCosine: number;
+    finalReacquireCorridorMinKm: number;
+};
+
+export type DockingCompletionConfig = {
+    finalHardLockThresholdKm: number;
+    completeMinTunnelPenetrationKm: number;
+    finalHardLockAlignmentCosine: number;
+    finalInsidePortCorridorMaxKm: number;
+    finalInsidePortMaxSpeed: number;
+    finalInsidePortThresholdKm: number;
+    completeStrictTunnelPenetrationKm: number;
+    finalInsidePortApproachMaxKm: number;
+    finalNearPortThresholdKm: number;
+    finalNearPortApproachMaxKm: number;
+    finalNearPortCorridorMaxKm: number;
+    finalNearPortMaxSpeed: number;
+    finalStageMinDurationMs: number;
+    portThresholdKm: number;
+    directPortAlignmentCosine: number;
+    directPortCorridorMaxKm: number;
+    directPortApproachMaxKm: number;
+    directPortMaxSpeed: number;
+    finalStageForceCompleteMs: number;
+    portFallbackThresholdKm: number;
+    fallbackAlignmentCosine: number;
+    fallbackCorridorMaxKm: number;
+};
+
+export type DockingRotationMatchConfig = {
+    rotationMatchMaxDistanceKm: number;
+    rotationMatchFinalDistanceKm: number;
+    rotationMatchHoldAlignAlignmentCosine: number;
+    rotationMatchFinalAlignmentCosine: number;
+    rotationMatchHoldAlignCorridorMaxKm: number;
+    rotationMatchFinalCorridorMaxKm: number;
+    rotationMatchReleaseAlignmentCosine: number;
+    rotationMatchReleaseCorridorMaxKm: number;
+    rotationMatchReleaseFinalCorridorMaxKm: number;
+};
+
+export const calculateDockingCameraPresentationBlend = (params: {
+    stage: DockingApproachStage;
+    distanceToPortKm: number;
+    presentationRangeKm: number;
+}): number => {
+    const { stage, distanceToPortKm, presentationRangeKm } = params;
+    if (presentationRangeKm <= 0) {
+        return 0;
+    }
+
+    const normalized = Math.max(0, Math.min(1, 1 - (distanceToPortKm / presentationRangeKm)));
+    if (stage === "final-approach") {
+        return normalized;
+    }
+    if (stage === "hold-align") {
+        return Math.max(0, Math.min(0.45, normalized * 0.45));
+    }
+    return 0;
+};
+
+export const calculateDockingScreenValidity = (params: {
+    ndcX: number;
+    ndcY: number;
+    inView: boolean;
+    centerMaxX: number;
+    centerMaxY: number;
+    strictCenterMaxX: number;
+    strictCenterMaxY: number;
+}): DockingScreenValidity => {
+    const {
+        ndcX,
+        ndcY,
+        inView,
+        centerMaxX,
+        centerMaxY,
+        strictCenterMaxX,
+        strictCenterMaxY,
+    } = params;
+    const portVisibleOnScreen = inView;
+    const portCenteredOnScreen = (
+        portVisibleOnScreen
+        && Math.abs(ndcX) <= centerMaxX
+        && Math.abs(ndcY) <= centerMaxY
+    );
+    const portStrictlyCenteredOnScreen = (
+        portVisibleOnScreen
+        && Math.abs(ndcX) <= strictCenterMaxX
+        && Math.abs(ndcY) <= strictCenterMaxY
+    );
+    return {
+        portVisibleOnScreen,
+        portCenteredOnScreen,
+        portStrictlyCenteredOnScreen,
+    };
+};
+
+export const resolveDockingStageTransition = (params: {
+    stage: DockingApproachStage;
+    nowMs: number;
+    stageStartedAtMs: number;
+    holdAlignAlignedSinceMs: number;
+    lastResetAtMs: number;
+    lastFinalReacquireAtMs: number;
+    holdEntryDistanceRemainingKm: number;
+    distanceToPortKm: number;
+    distanceToApproachPointKm: number;
+    stageDistanceRemainingKm: number;
+    reticleAlignmentCosine: number;
+    corridorLateralOffsetKm: number;
+    tunnelPenetrationDepthKm: number;
+    config: DockingTransitionConfig;
+}): DockingStageTransition | null => {
+    const {
+        stage,
+        nowMs,
+        stageStartedAtMs,
+        holdAlignAlignedSinceMs,
+        lastResetAtMs,
+        lastFinalReacquireAtMs,
+        holdEntryDistanceRemainingKm,
+        distanceToPortKm,
+        reticleAlignmentCosine,
+        corridorLateralOffsetKm,
+        tunnelPenetrationDepthKm,
+        config,
+    } = params;
+
+    if (stage === "hold-entry") {
+        const holdEntryElapsedMs = nowMs - stageStartedAtMs;
+        const holdEntryReadyForAlign = (
+            holdEntryDistanceRemainingKm <= config.holdPointThresholdKm
+            && holdEntryElapsedMs >= config.holdEntryMinDurationMs
+            && reticleAlignmentCosine >= config.holdEntryAlignCosine
+            && corridorLateralOffsetKm <= config.holdEntryCorridorToleranceKm
+        );
+        return holdEntryReadyForAlign
+            ? { nextStage: "hold-align", reason: "hold-entry-threshold-reached" }
+            : null;
+    }
+
+    if (stage === "hold-align") {
+        const holdAlignElapsedMs = nowMs - stageStartedAtMs;
+        const holdAlignAligned = (
+            reticleAlignmentCosine >= config.holdAlignRequiredCosine
+            && params.stageDistanceRemainingKm <= config.holdPointThresholdKm
+            && corridorLateralOffsetKm <= config.holdAlignCorridorToleranceKm
+        );
+        const holdAlignStableMs = holdAlignAligned && holdAlignAlignedSinceMs > 0
+            ? nowMs - holdAlignAlignedSinceMs
+            : 0;
+        const holdAlignTimeout = holdAlignElapsedMs >= config.holdAlignMaxDurationMs;
+        const holdAlignTimeoutEligible = (
+            reticleAlignmentCosine >= config.holdAlignTimeoutRequiredCosine
+            && corridorLateralOffsetKm <= config.holdAlignTimeoutCorridorToleranceKm
+            && distanceToPortKm <= config.holdAlignTimeoutMaxDistanceKm
+            && distanceToPortKm <= config.holdAlignFinalEntryMaxDistanceKm
+        );
+        if (
+            (holdAlignTimeout && holdAlignTimeoutEligible)
+            || (
+                distanceToPortKm <= config.holdAlignFinalEntryMaxDistanceKm
+                && holdAlignElapsedMs >= config.holdAlignDurationMs
+                && holdAlignStableMs >= config.holdAlignStableMs
+            )
+        ) {
+            return {
+                nextStage: "tunnel-entry",
+                reason: holdAlignTimeout ? "hold-align-timeout-eligible" : "hold-align-stable",
+            };
+        }
+
+        const holdAlignResetEligible = (
+            holdAlignElapsedMs >= config.holdAlignResetTimeoutMs
+            && (nowMs - lastResetAtMs) >= config.holdAlignResetCooldownMs
+            && (
+                reticleAlignmentCosine <= config.holdAlignResetAlignmentCosine
+                || corridorLateralOffsetKm >= config.holdAlignResetCorridorMinKm
+            )
+        );
+        return holdAlignResetEligible
+            ? { nextStage: "hold-entry", reason: "hold-align-reset-reapproach" }
+            : null;
+    }
+
+    if (stage === "tunnel-entry") {
+        const tunnelEntryElapsedMs = nowMs - stageStartedAtMs;
+        const tunnelEntryReadyForFinal = (
+            tunnelEntryElapsedMs >= config.tunnelEntryMinDurationMs
+            && tunnelPenetrationDepthKm >= config.tunnelEntryFinalTriggerKm
+            && corridorLateralOffsetKm <= config.finalInsidePortCorridorMaxKm
+            && reticleAlignmentCosine >= config.finalHardLockAlignmentCosine
+        );
+        return tunnelEntryReadyForFinal
+            ? { nextStage: "final-approach", reason: "tunnel-entry-depth-reached" }
+            : null;
+    }
+
+    if (stage === "final-approach") {
+        const finalApproachElapsedMs = nowMs - stageStartedAtMs;
+        const reacquireEligible = (
+            finalApproachElapsedMs >= config.finalReacquireMinElapsedMs
+            && (nowMs - lastFinalReacquireAtMs) >= config.finalReacquireCooldownMs
+            && distanceToPortKm > config.finalReacquireMinDistanceKm
+            && (
+                reticleAlignmentCosine <= config.finalReacquireAlignmentCosine
+                || corridorLateralOffsetKm >= config.finalReacquireCorridorMinKm
+            )
+        );
+        return reacquireEligible
+            ? { nextStage: "hold-align", reason: "final-approach-reacquire" }
+            : null;
+    }
+
+    return null;
+};
+
+export const resolveDockingRotationMatch = (params: {
+    stage: DockingApproachStage;
+    rotationMatchEnabled: boolean;
+    rotationMatchLatched: boolean;
+    distanceToPortKm: number;
+    reticleAlignmentCosine: number;
+    corridorLateralOffsetKm: number;
+    config: DockingRotationMatchConfig;
+}): boolean => {
+    const {
+        stage,
+        rotationMatchEnabled,
+        rotationMatchLatched,
+        distanceToPortKm,
+        reticleAlignmentCosine,
+        corridorLateralOffsetKm,
+        config,
+    } = params;
+    if (!rotationMatchEnabled || stage === "hold-entry") {
+        return false;
+    }
+
+    const inRange = distanceToPortKm <= config.rotationMatchMaxDistanceKm;
+    const matchDistanceLimit = stage === "final-approach"
+        ? config.rotationMatchFinalDistanceKm
+        : config.rotationMatchMaxDistanceKm;
+    const matchAlignmentThreshold = stage === "final-approach"
+        ? config.rotationMatchFinalAlignmentCosine
+        : config.rotationMatchHoldAlignAlignmentCosine;
+    const matchCorridorMax = stage === "final-approach"
+        ? config.rotationMatchFinalCorridorMaxKm
+        : config.rotationMatchHoldAlignCorridorMaxKm;
+    const releaseCorridorMax = stage === "final-approach"
+        ? config.rotationMatchReleaseFinalCorridorMaxKm
+        : config.rotationMatchReleaseCorridorMaxKm;
+
+    const shouldMatchStationRotation = (
+        inRange
+        && distanceToPortKm <= matchDistanceLimit
+        && reticleAlignmentCosine >= matchAlignmentThreshold
+        && corridorLateralOffsetKm <= matchCorridorMax
+    );
+    const shouldKeepRotationMatch = (
+        rotationMatchLatched
+        && inRange
+        && distanceToPortKm <= matchDistanceLimit
+        && reticleAlignmentCosine >= config.rotationMatchReleaseAlignmentCosine
+        && corridorLateralOffsetKm <= releaseCorridorMax
+    );
+    return shouldMatchStationRotation || shouldKeepRotationMatch;
+};
+
+export const resolveDockingCompletionWindow = (params: {
+    finalApproachElapsedMs: number;
+    distanceToPortKm: number;
+    tunnelPenetrationDepthKm: number;
+    reticleAlignmentCosine: number;
+    corridorLateralOffsetKm: number;
+    shipSpeedKmPerSec: number;
+    distanceToApproachPointKm: number;
+    screenValidity: DockingScreenValidity;
+    config: DockingCompletionConfig;
+}): DockingCompletionWindow => {
+    const {
+        finalApproachElapsedMs,
+        distanceToPortKm,
+        tunnelPenetrationDepthKm,
+        reticleAlignmentCosine,
+        corridorLateralOffsetKm,
+        shipSpeedKmPerSec,
+        distanceToApproachPointKm,
+        screenValidity,
+        config,
+    } = params;
+
+    const hardLockWindowReached = (
+        distanceToPortKm <= config.finalHardLockThresholdKm
+        && tunnelPenetrationDepthKm >= config.completeMinTunnelPenetrationKm
+        && reticleAlignmentCosine >= config.finalHardLockAlignmentCosine
+        && corridorLateralOffsetKm <= config.finalInsidePortCorridorMaxKm
+        && shipSpeedKmPerSec <= config.finalInsidePortMaxSpeed
+        && screenValidity.portCenteredOnScreen
+    );
+    if (hardLockWindowReached) {
+        return { completed: true, reason: "hard-lock-window" };
+    }
+
+    const insidePortWindowReached = (
+        distanceToPortKm <= config.finalInsidePortThresholdKm
+        && tunnelPenetrationDepthKm >= config.completeStrictTunnelPenetrationKm
+        && distanceToApproachPointKm <= config.finalInsidePortApproachMaxKm
+        && corridorLateralOffsetKm <= config.finalInsidePortCorridorMaxKm
+        && shipSpeedKmPerSec <= config.finalInsidePortMaxSpeed
+        && screenValidity.portCenteredOnScreen
+    );
+    if (insidePortWindowReached) {
+        return { completed: true, reason: "inside-port-window" };
+    }
+
+    const nearPortWindowReached = (
+        distanceToPortKm <= config.finalNearPortThresholdKm
+        && tunnelPenetrationDepthKm >= config.completeStrictTunnelPenetrationKm
+        && distanceToApproachPointKm <= config.finalNearPortApproachMaxKm
+        && corridorLateralOffsetKm <= config.finalNearPortCorridorMaxKm
+        && shipSpeedKmPerSec <= config.finalNearPortMaxSpeed
+        && screenValidity.portStrictlyCenteredOnScreen
+    );
+    if (nearPortWindowReached) {
+        return { completed: true, reason: "near-port-window" };
+    }
+
+    if (finalApproachElapsedMs < config.finalStageMinDurationMs) {
+        return { completed: false, reason: null };
+    }
+
+    const directPortWindowReached = (
+        distanceToPortKm <= config.portThresholdKm
+        && tunnelPenetrationDepthKm >= config.completeStrictTunnelPenetrationKm
+        && reticleAlignmentCosine >= config.directPortAlignmentCosine
+        && corridorLateralOffsetKm <= config.directPortCorridorMaxKm
+        && distanceToApproachPointKm <= config.directPortApproachMaxKm
+        && shipSpeedKmPerSec <= config.directPortMaxSpeed
+        && screenValidity.portStrictlyCenteredOnScreen
+    );
+    if (directPortWindowReached) {
+        return { completed: true, reason: "direct-port-window" };
+    }
+
+    const fallbackWindowReached = (
+        finalApproachElapsedMs >= config.finalStageForceCompleteMs
+        && distanceToPortKm <= config.portFallbackThresholdKm
+        && tunnelPenetrationDepthKm >= config.completeMinTunnelPenetrationKm
+        && distanceToApproachPointKm <= config.portThresholdKm
+        && reticleAlignmentCosine >= config.fallbackAlignmentCosine
+        && corridorLateralOffsetKm <= config.fallbackCorridorMaxKm
+        && shipSpeedKmPerSec <= config.directPortMaxSpeed
+        && screenValidity.portCenteredOnScreen
+    );
+    return fallbackWindowReached
+        ? { completed: true, reason: "fallback-window" }
+        : { completed: false, reason: null };
+};

--- a/frontend/src/components/ui/FlightScene.math.ts
+++ b/frontend/src/components/ui/FlightScene.math.ts
@@ -120,3 +120,67 @@ export const advanceDockingAttitude = (params: {
         pitchRadians: nextPitch,
     };
 };
+
+export type ProjectedCameraSpacePoint = {
+    depth: number;
+    ndcX: number;
+    ndcY: number;
+    inFront: boolean;
+    inView: boolean;
+};
+
+export const projectCameraSpacePointToNdc = (params: {
+    cameraSpaceX: number;
+    cameraSpaceY: number;
+    cameraSpaceZ: number;
+    verticalFovDegrees: number;
+    aspectRatio: number;
+}): ProjectedCameraSpacePoint => {
+    const {
+        cameraSpaceX,
+        cameraSpaceY,
+        cameraSpaceZ,
+        verticalFovDegrees,
+        aspectRatio,
+    } = params;
+
+    const depth = -cameraSpaceZ;
+    if (
+        !Number.isFinite(depth)
+        || depth <= 0
+        || !Number.isFinite(verticalFovDegrees)
+        || verticalFovDegrees <= 0
+        || !Number.isFinite(aspectRatio)
+        || aspectRatio <= 0
+    ) {
+        return {
+            depth,
+            ndcX: Number.POSITIVE_INFINITY,
+            ndcY: Number.POSITIVE_INFINITY,
+            inFront: false,
+            inView: false,
+        };
+    }
+
+    const halfVerticalSpan = Math.tan((verticalFovDegrees * Math.PI) / 360) * depth;
+    const halfHorizontalSpan = halfVerticalSpan * aspectRatio;
+    if (halfVerticalSpan <= 0 || halfHorizontalSpan <= 0) {
+        return {
+            depth,
+            ndcX: Number.POSITIVE_INFINITY,
+            ndcY: Number.POSITIVE_INFINITY,
+            inFront: true,
+            inView: false,
+        };
+    }
+
+    const ndcX = cameraSpaceX / halfHorizontalSpan;
+    const ndcY = cameraSpaceY / halfVerticalSpan;
+    return {
+        depth,
+        ndcX,
+        ndcY,
+        inFront: true,
+        inView: Math.abs(ndcX) <= 1 && Math.abs(ndcY) <= 1,
+    };
+};

--- a/frontend/src/components/ui/FlightScene.tsx
+++ b/frontend/src/components/ui/FlightScene.tsx
@@ -11,7 +11,16 @@ import {
     desiredDockingPitchFromDirection,
     desiredDockingYawFromDirection,
     normalizeSignedAngle,
+    projectCameraSpacePointToNdc,
 } from "./FlightScene.math";
+import {
+    calculateDockingCameraPresentationBlend,
+    calculateDockingScreenValidity,
+    resolveDockingCompletionWindow,
+    resolveDockingRotationMatch,
+    resolveDockingStageTransition,
+} from "./FlightScene.docking";
+import type { DockingApproachStage } from "./FlightScene.docking";
 import styles from "./FlightScene.module.css";
 
 type ScannerAnchorContact = {
@@ -22,6 +31,9 @@ type ScannerAnchorContact = {
     radius_km?: number | null;
     name: string;
     distance_km: number;
+    relative_x_km?: number;
+    relative_y_km?: number;
+    relative_z_km?: number;
     scene_x: number;
     scene_y: number;
     scene_z: number;
@@ -30,11 +42,30 @@ type ScannerAnchorContact = {
     ship_visual_key?: string | null;
 };
 
+type CelestialPresentationAnchor = {
+    id: string;
+    contact_type: "planet" | "moon" | "star";
+    name: string;
+    distance_km: number;
+    orbiting_planet_name?: string | null;
+    body_kind: "star" | "planet" | "moon";
+    body_type?: string | null;
+    radius_km?: number | null;
+    relative_x_km?: number;
+    relative_y_km?: number;
+    relative_z_km?: number;
+    presentation_x: number;
+    presentation_y: number;
+    presentation_z: number;
+};
+
 type FlightSceneSpawnDirective = {
     mode: "undock-exit";
     stationContactId: string;
     nonce: number;
 };
+
+type FlightCameraMode = "boresight" | "cockpit";
 
 type FlightSceneProps = {
     jumpPhase:
@@ -49,12 +80,13 @@ type FlightSceneProps = {
     | "error";
     jumpProgress: number;
     renderProfile: "performance" | "balanced" | "cinematic";
+    cameraMode?: FlightCameraMode;
     shipVisualKey?: string | null;
     stationShapeKey?: string | null;
     transitStationLabel?: string | null;
     focusedContact: ScannerAnchorContact | null;
     scannerContacts: ScannerAnchorContact[];
-    celestialAnchors: ScannerAnchorContact[];
+    celestialAnchors: CelestialPresentationAnchor[];
     onSpeedChange?: (speed: number) => void;
     onRollChange?: (rollDegrees: number) => void;
     onScannerTelemetryChange?: (contacts: ScannerTelemetryContact[]) => void;
@@ -65,9 +97,11 @@ type FlightSceneProps = {
         progress: number;
         distanceKm: number;
         targetName: string;
-        stage: "hold-entry" | "hold-align" | "final-approach";
+        stage: "hold-entry" | "hold-align" | "tunnel-entry" | "final-approach";
     }) => void;
     onDockingApproachComplete?: () => void;
+    onDockingDebug?: (payload: DockingDebugPayload) => void;
+    dockingRotationMatchEnabled?: boolean;
     showContactLabels?: boolean;
     spawnDirective?: FlightSceneSpawnDirective | null;
     onSpawnDirectiveApplied?: (nonce: number) => void;
@@ -90,11 +124,45 @@ type FlightSceneCollisionEvent = {
     severity: "glancing" | "critical";
 };
 
+type DockingDebugPayload = {
+    event:
+    | "contact-missing"
+    | "target-acquired"
+    | "stage-transition"
+    | "telemetry"
+    | "complete-window";
+    jumpPhase: FlightSceneProps["jumpPhase"];
+    contactId: string;
+    targetName?: string;
+    stage?: DockingApproachStage;
+    reason?: string;
+    distanceToPortKm?: number;
+    distanceToApproachPointKm?: number;
+    stageDistanceRemainingKm?: number;
+    reticleAlignmentCosine?: number;
+    corridorLateralOffsetKm?: number;
+    shouldMatchStationRotation?: boolean;
+    stationRotationRadians?: number;
+    shipSpeedKmPerSec?: number;
+    shipPosition?: { x: number; y: number; z: number };
+    portCorePosition?: { x: number; y: number; z: number };
+    portApproachPosition?: { x: number; y: number; z: number };
+    stationCenter?: { x: number; y: number; z: number };
+    portVisibleOnScreen?: boolean;
+    portCenteredOnScreen?: boolean;
+    portScreenOffsetX?: number;
+    portScreenOffsetY?: number;
+    portScreenDepthKm?: number;
+};
+
 type ScannerTelemetryContact = {
     id: string;
     relative_x: number;
     relative_y: number;
     relative_z: number;
+    relative_x_km?: number;
+    relative_y_km?: number;
+    relative_z_km?: number;
     forward_distance: number;
     plane_x: number;
     plane_y: number;
@@ -119,8 +187,6 @@ type InputState = {
     pitchUp: boolean;
     pitchDown: boolean;
 };
-
-type DockingApproachStage = "hold-entry" | "hold-align" | "final-approach";
 
 const clamp = (value: number, min: number, max: number): number => {
     if (value < min) {
@@ -168,6 +234,7 @@ const CELESTIAL_LOD_DISTANCE_KM = {
     near: 140_000,
     mid: 880_000,
 };
+const LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM = 1;
 
 const normalizeHeading = (angle: number): number => {
     if (!Number.isFinite(angle)) {
@@ -193,7 +260,7 @@ function anchorColor(contactType: ScannerAnchorContact["contact_type"]): string 
     return "#8fb3ff";
 }
 
-function resolveCelestialAnchorColor(contact: ScannerAnchorContact): string {
+function resolveCelestialAnchorColor(contact: CelestialPresentationAnchor): string {
     const bodyKind = contact.body_kind;
     const bodyType = (contact.body_type || "").trim().toLowerCase();
 
@@ -233,7 +300,7 @@ function resolveCelestialAnchorColor(contact: ScannerAnchorContact): string {
     return anchorColor(contact.contact_type);
 }
 
-function resolveCelestialAnchorSize(contact: ScannerAnchorContact): number {
+function resolveCelestialAnchorSize(contact: CelestialPresentationAnchor): number {
     const radiusKm = Number(contact.radius_km);
     const bodyKind = contact.body_kind;
     const bodyType = (contact.body_type || "").trim().toLowerCase();
@@ -265,7 +332,7 @@ function resolveCelestialAnchorSize(contact: ScannerAnchorContact): number {
     return anchorSize(contact.contact_type);
 }
 
-function resolveCelestialLodTier(contact: ScannerAnchorContact): "near" | "mid" | "far" {
+function resolveCelestialLodTier(contact: CelestialPresentationAnchor): "near" | "mid" | "far" {
     const distanceKm = Number(contact.distance_km);
     if (!Number.isFinite(distanceKm)) {
         return "mid";
@@ -279,7 +346,7 @@ function resolveCelestialLodTier(contact: ScannerAnchorContact): "near" | "mid" 
     return "far";
 }
 
-function resolveCelestialSphereSegments(contact: ScannerAnchorContact): [number, number] {
+function resolveCelestialSphereSegments(contact: CelestialPresentationAnchor): [number, number] {
     const tier = resolveCelestialLodTier(contact);
     const baseSegments = CELESTIAL_SPHERE_SEGMENTS_BY_TIER[tier];
     if (contact.body_kind === "star") {
@@ -288,13 +355,13 @@ function resolveCelestialSphereSegments(contact: ScannerAnchorContact): [number,
     return [baseSegments, baseSegments];
 }
 
-function resolveCelestialOverlaySegments(contact: ScannerAnchorContact): [number, number] {
+function resolveCelestialOverlaySegments(contact: CelestialPresentationAnchor): [number, number] {
     const tier = resolveCelestialLodTier(contact);
     const baseSegments = CELESTIAL_OVERLAY_SEGMENTS_BY_TIER[tier];
     return [baseSegments, baseSegments];
 }
 
-function contactHashUnit(contact: ScannerAnchorContact): number {
+function contactHashUnit(contact: CelestialPresentationAnchor): number {
     let hash = 2166136261;
     const key = `${contact.id}:${contact.name}:${contact.body_type ?? ""}`;
     for (let index = 0; index < key.length; index += 1) {
@@ -304,7 +371,7 @@ function contactHashUnit(contact: ScannerAnchorContact): number {
     return (hash >>> 0) / 4294967295;
 }
 
-function resolveSurfaceAccentColor(contact: ScannerAnchorContact): string {
+function resolveSurfaceAccentColor(contact: CelestialPresentationAnchor): string {
     const bodyType = (contact.body_type || "").trim().toLowerCase();
     if (bodyType === "oceanic") {
         return "#6fbf75";
@@ -324,7 +391,7 @@ function resolveSurfaceAccentColor(contact: ScannerAnchorContact): string {
     return "#6fa890";
 }
 
-function resolveCloudLayer(contact: ScannerAnchorContact): {
+function resolveCloudLayer(contact: CelestialPresentationAnchor): {
     color: string;
     opacity: number;
 } | null {
@@ -341,7 +408,7 @@ function resolveCloudLayer(contact: ScannerAnchorContact): {
     return { color: "#e8f4ff", opacity: 0.22 };
 }
 
-function shouldRenderPlanetRing(contact: ScannerAnchorContact): boolean {
+function shouldRenderPlanetRing(contact: CelestialPresentationAnchor): boolean {
     if (contact.body_kind !== "planet") {
         return false;
     }
@@ -368,8 +435,65 @@ function anchorSize(contactType: ScannerAnchorContact["contact_type"]): number {
     return 0.32;
 }
 
+function contactHasPhysicalLocalCoordinates(contact: ScannerAnchorContact): boolean {
+    return (
+        Number.isFinite(contact.relative_x_km)
+        && Number.isFinite(contact.relative_y_km)
+        && Number.isFinite(contact.relative_z_km)
+    );
+}
+
+function contactUsesPhysicalNearFieldSpace(contact: ScannerAnchorContact): boolean {
+    return contactHasPhysicalLocalCoordinates(contact);
+}
+
+function resolveContactRenderPosition(
+    contact: ScannerAnchorContact,
+    out: Vector3,
+): Vector3 {
+    if (contactUsesPhysicalNearFieldSpace(contact)) {
+        return out.set(
+            Number(contact.relative_x_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(contact.relative_y_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(contact.relative_z_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+        );
+    }
+
+    return out.set(contact.scene_x, contact.scene_y, contact.scene_z);
+}
+
 function sceneAnchorPosition(contact: ScannerAnchorContact): [number, number, number] {
+    if (contactUsesPhysicalNearFieldSpace(contact)) {
+        return [
+            Number(contact.relative_x_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(contact.relative_y_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(contact.relative_z_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+        ];
+    }
     return [contact.scene_x, contact.scene_y, contact.scene_z];
+}
+
+function celestialAnchorPosition(anchor: CelestialPresentationAnchor): [number, number, number] {
+    if (
+        Number.isFinite(anchor.relative_x_km)
+        && Number.isFinite(anchor.relative_y_km)
+        && Number.isFinite(anchor.relative_z_km)
+    ) {
+        return [
+            Number(anchor.relative_x_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(anchor.relative_y_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+            Number(anchor.relative_z_km) * LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM,
+        ];
+    }
+    return [anchor.presentation_x, anchor.presentation_y, anchor.presentation_z];
+}
+
+function resolveContactMarkerPosition(
+    contact: ScannerAnchorContact,
+    celestialAnchor: CelestialPresentationAnchor | null,
+): [number, number, number] {
+    void celestialAnchor;
+    return sceneAnchorPosition(contact);
 }
 
 type ShipVisualKey = "cobra-mk1" | "default";
@@ -538,57 +662,607 @@ const STATION_BASE_RADIUS_BY_SHAPE: Record<StationShapeKey, number> = {
 };
 
 const STATION_DOCKING_PORT_LOCAL_ANCHOR_BY_SHAPE: Record<StationShapeKey, [number, number, number]> = {
-    coriolis: [0, 0, 5.62],
+    coriolis: [0, 0, 5.56],
     orbis: [0, 0, 5.1],
     default: [0, 0, 3.55],
 };
+
+const STATION_ROTATION_RATE_BY_SHAPE: Record<StationShapeKey, number> = {
+    coriolis: 0.22,
+    orbis: 0.14,
+    default: 0.12,
+};
+
+function resolveStationRotationRadians(
+    contact: ScannerAnchorContact,
+    elapsedSeconds: number,
+): number {
+    const shape = resolveStationShapeKey(contact.station_archetype_shape);
+    const rotationRate = STATION_ROTATION_RATE_BY_SHAPE[shape]
+        ?? STATION_ROTATION_RATE_BY_SHAPE.default;
+    const phaseSeed = `${contact.id}:${contact.name}`;
+    let hash = 0;
+    for (let index = 0; index < phaseSeed.length; index += 1) {
+        hash = ((hash * 31) + phaseSeed.charCodeAt(index)) >>> 0;
+    }
+    const phaseRadians = ((hash % 360) * Math.PI) / 180;
+    return (elapsedSeconds * rotationRate) + phaseRadians;
+}
 
 function resolveStationBaseRadius(shape: StationShapeKey): number {
     return STATION_BASE_RADIUS_BY_SHAPE[shape] ?? STATION_BASE_RADIUS_BY_SHAPE.default;
 }
 
+function resolveStationRenderScale(contact: ScannerAnchorContact): number {
+    if (contactHasPhysicalLocalCoordinates(contact)) {
+        return LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM;
+    }
+    return stationDistanceScale(contact.distance_km);
+}
+
 function resolveDockingPortWorldPosition(
     contact: ScannerAnchorContact,
     out: Vector3,
+    elapsedSeconds: number,
+    options?: { trackRotation?: boolean },
 ): Vector3 {
     const shape = resolveStationShapeKey(contact.station_archetype_shape);
-    const distanceScale = stationDistanceScale(contact.distance_km);
+    const distanceScale = resolveStationRenderScale(contact);
     const [localX, localY, localZ] = STATION_DOCKING_PORT_LOCAL_ANCHOR_BY_SHAPE[shape]
         ?? STATION_DOCKING_PORT_LOCAL_ANCHOR_BY_SHAPE.default;
+    const rotationRadians = options?.trackRotation === false
+        ? 0
+        : resolveStationRotationRadians(contact, elapsedSeconds);
+    const sinRotation = Math.sin(rotationRadians);
+    const cosRotation = Math.cos(rotationRadians);
+    const rotatedLocalX = (localX * cosRotation) - (localY * sinRotation);
+    const rotatedLocalY = (localX * sinRotation) + (localY * cosRotation);
 
-    return out.set(
-        contact.scene_x + (localX * distanceScale),
-        contact.scene_y + (localY * distanceScale),
-        contact.scene_z + (localZ * distanceScale),
+    resolveContactRenderPosition(contact, out);
+    out.x += rotatedLocalX * distanceScale;
+    out.y += rotatedLocalY * distanceScale;
+    out.z += localZ * distanceScale;
+    return out;
+}
+
+function RectDockingTunnelInsert({
+    positionZ,
+    outerWidth,
+    outerHeight,
+    innerWidth,
+    innerHeight,
+    depth,
+    guideLightColor = "#89c8ff",
+    guideFrameCount = 6,
+    showLandingPadTerminus = false,
+}: {
+    positionZ: number;
+    outerWidth: number;
+    outerHeight: number;
+    innerWidth: number;
+    innerHeight: number;
+    depth: number;
+    guideLightColor?: string;
+    guideFrameCount?: number;
+    showLandingPadTerminus?: boolean;
+}): ReactElement {
+    const sideWallWidth = Math.max(0.06, (outerWidth - innerWidth) / 2);
+    const topWallHeight = Math.max(0.06, (outerHeight - innerHeight) / 2);
+    const sideOffsetX = (innerWidth / 2) + (sideWallWidth / 2);
+    const topOffsetY = (innerHeight / 2) + (topWallHeight / 2);
+    const lipDepth = Math.max(0.08, depth * 0.08);
+    const frameThickness = Math.max(0.018, Math.min(innerWidth, innerHeight) * 0.044);
+    const guideInset = frameThickness * 1.2;
+    const guideStartZ = (depth / 2) - 0.34;
+    const guideEndZ = (-depth / 2) + 0.4;
+    const guideFrameSafeCount = Math.max(3, guideFrameCount);
+    const backWallZ = (-depth / 2) + 0.06;
+
+    return (
+        <group position={[0, 0, positionZ]}>
+            <mesh position={[-sideOffsetX, 0, 0]}>
+                <boxGeometry args={[sideWallWidth, outerHeight, depth]} />
+                <meshStandardMaterial
+                    color="#04080f"
+                    emissive="#08131d"
+                    emissiveIntensity={0.16}
+                    metalness={0.03}
+                    roughness={0.96}
+                />
+            </mesh>
+            <mesh position={[sideOffsetX, 0, 0]}>
+                <boxGeometry args={[sideWallWidth, outerHeight, depth]} />
+                <meshStandardMaterial
+                    color="#04080f"
+                    emissive="#08131d"
+                    emissiveIntensity={0.16}
+                    metalness={0.03}
+                    roughness={0.96}
+                />
+            </mesh>
+            <mesh position={[0, topOffsetY, 0]}>
+                <boxGeometry args={[innerWidth, topWallHeight, depth]} />
+                <meshStandardMaterial
+                    color="#050a12"
+                    emissive="#0a1622"
+                    emissiveIntensity={0.14}
+                    metalness={0.03}
+                    roughness={0.96}
+                />
+            </mesh>
+            <mesh position={[0, -topOffsetY, 0]}>
+                <boxGeometry args={[innerWidth, topWallHeight, depth]} />
+                <meshStandardMaterial
+                    color="#050a12"
+                    emissive="#0a1622"
+                    emissiveIntensity={0.14}
+                    metalness={0.03}
+                    roughness={0.96}
+                />
+            </mesh>
+            <mesh position={[0, topOffsetY, (depth / 2) - (lipDepth / 2)]}>
+                <boxGeometry args={[innerWidth, topWallHeight * 0.88, lipDepth]} />
+                <meshStandardMaterial
+                    color="#0b1420"
+                    emissive="#173148"
+                    emissiveIntensity={0.26}
+                    metalness={0.08}
+                    roughness={0.82}
+                />
+            </mesh>
+            <mesh position={[0, -topOffsetY, (depth / 2) - (lipDepth / 2)]}>
+                <boxGeometry args={[innerWidth, topWallHeight * 0.88, lipDepth]} />
+                <meshStandardMaterial
+                    color="#0b1420"
+                    emissive="#173148"
+                    emissiveIntensity={0.26}
+                    metalness={0.08}
+                    roughness={0.82}
+                />
+            </mesh>
+            <mesh position={[-sideOffsetX, 0, (depth / 2) - (lipDepth / 2)]}>
+                <boxGeometry args={[sideWallWidth * 0.88, innerHeight, lipDepth]} />
+                <meshStandardMaterial
+                    color="#0b1420"
+                    emissive="#173148"
+                    emissiveIntensity={0.26}
+                    metalness={0.08}
+                    roughness={0.82}
+                />
+            </mesh>
+            <mesh position={[sideOffsetX, 0, (depth / 2) - (lipDepth / 2)]}>
+                <boxGeometry args={[sideWallWidth * 0.88, innerHeight, lipDepth]} />
+                <meshStandardMaterial
+                    color="#0b1420"
+                    emissive="#173148"
+                    emissiveIntensity={0.26}
+                    metalness={0.08}
+                    roughness={0.82}
+                />
+            </mesh>
+
+            {Array.from({ length: guideFrameSafeCount }, (_, index) => {
+                const ratio = guideFrameSafeCount === 1
+                    ? 0
+                    : index / (guideFrameSafeCount - 1);
+                const frameWidth = Math.max(
+                    innerWidth * 0.46,
+                    innerWidth - (guideInset * ratio * 2.2),
+                );
+                const frameHeight = Math.max(
+                    innerHeight * 0.46,
+                    innerHeight - (guideInset * ratio * 1.8),
+                );
+                const frameZ = guideStartZ - ((guideStartZ - guideEndZ) * ratio);
+                const emissiveIntensity = index === 0 ? 0.82 : index % 2 === 0 ? 0.54 : 0.38;
+                return (
+                    <group key={`rect-docking-guide-${index}`} position={[0, 0, frameZ]}>
+                        <mesh position={[0, frameHeight / 2, 0]}>
+                            <boxGeometry args={[frameWidth, frameThickness, frameThickness]} />
+                            <meshStandardMaterial
+                                color={guideLightColor}
+                                emissive={guideLightColor}
+                                emissiveIntensity={emissiveIntensity}
+                                metalness={0.22}
+                                roughness={0.24}
+                            />
+                        </mesh>
+                        <mesh position={[0, -(frameHeight / 2), 0]}>
+                            <boxGeometry args={[frameWidth, frameThickness, frameThickness]} />
+                            <meshStandardMaterial
+                                color={guideLightColor}
+                                emissive={guideLightColor}
+                                emissiveIntensity={emissiveIntensity}
+                                metalness={0.22}
+                                roughness={0.24}
+                            />
+                        </mesh>
+                        <mesh position={[-(frameWidth / 2), 0, 0]}>
+                            <boxGeometry args={[frameThickness, frameHeight, frameThickness]} />
+                            <meshStandardMaterial
+                                color={guideLightColor}
+                                emissive={guideLightColor}
+                                emissiveIntensity={emissiveIntensity}
+                                metalness={0.22}
+                                roughness={0.24}
+                            />
+                        </mesh>
+                        <mesh position={[frameWidth / 2, 0, 0]}>
+                            <boxGeometry args={[frameThickness, frameHeight, frameThickness]} />
+                            <meshStandardMaterial
+                                color={guideLightColor}
+                                emissive={guideLightColor}
+                                emissiveIntensity={emissiveIntensity}
+                                metalness={0.22}
+                                roughness={0.24}
+                            />
+                        </mesh>
+                    </group>
+                );
+            })}
+
+            {showLandingPadTerminus ? (
+                <group position={[0, 0, backWallZ + 0.02]}>
+                    <mesh position={[0, 0, 0.04]}>
+                        <boxGeometry args={[innerWidth * 1.08, innerHeight * 1.08, 0.78]} />
+                        <meshStandardMaterial
+                            color="#02050a"
+                            emissive="#040a12"
+                            emissiveIntensity={0.04}
+                            metalness={0.02}
+                            roughness={0.98}
+                        />
+                    </mesh>
+                    <mesh position={[0, 0.02, 0.44]}>
+                        <planeGeometry args={[innerWidth * 0.74, innerHeight * 0.7]} />
+                        <meshStandardMaterial
+                            color="#02050a"
+                            emissive="#060d16"
+                            emissiveIntensity={0.05}
+                            metalness={0.02}
+                            roughness={0.98}
+                            side={DoubleSide}
+                        />
+                    </mesh>
+                    <mesh position={[0, -(innerHeight * 0.35), 0.5]}>
+                        <boxGeometry args={[innerWidth * 0.78, innerHeight * 0.08, 0.12]} />
+                        <meshStandardMaterial
+                            color="#0c131b"
+                            emissive="#09111a"
+                            emissiveIntensity={0.08}
+                            metalness={0.12}
+                            roughness={0.9}
+                        />
+                    </mesh>
+                    <mesh position={[0, -(innerHeight * 0.325), 0.59]}>
+                        <boxGeometry args={[innerWidth * 0.48, innerHeight * 0.018, 0.026]} />
+                        <meshStandardMaterial
+                            color={guideLightColor}
+                            emissive={guideLightColor}
+                            emissiveIntensity={0.78}
+                            metalness={0.14}
+                            roughness={0.28}
+                        />
+                    </mesh>
+                    <mesh position={[0, -(innerHeight * 0.25), 0.54]}>
+                        <boxGeometry args={[innerWidth * 0.045, innerHeight * 0.12, 0.018]} />
+                        <meshStandardMaterial
+                            color={guideLightColor}
+                            emissive={guideLightColor}
+                            emissiveIntensity={0.52}
+                            metalness={0.14}
+                            roughness={0.28}
+                        />
+                    </mesh>
+                    <mesh position={[0, -(innerHeight * 0.25), 0.54]}>
+                        <boxGeometry args={[innerWidth * 0.18, innerHeight * 0.018, 0.018]} />
+                        <meshStandardMaterial
+                            color={guideLightColor}
+                            emissive={guideLightColor}
+                            emissiveIntensity={0.52}
+                            metalness={0.14}
+                            roughness={0.28}
+                        />
+                    </mesh>
+                    <mesh position={[-(innerWidth * 0.28), -(innerHeight * 0.325), 0.56]}>
+                        <boxGeometry args={[innerWidth * 0.045, innerHeight * 0.05, 0.04]} />
+                        <meshStandardMaterial
+                            color="#d2f1ff"
+                            emissive="#a8e8ff"
+                            emissiveIntensity={0.66}
+                            metalness={0.06}
+                            roughness={0.36}
+                        />
+                    </mesh>
+                    <mesh position={[innerWidth * 0.28, -(innerHeight * 0.325), 0.56]}>
+                        <boxGeometry args={[innerWidth * 0.045, innerHeight * 0.05, 0.04]} />
+                        <meshStandardMaterial
+                            color="#d2f1ff"
+                            emissive="#a8e8ff"
+                            emissiveIntensity={0.66}
+                            metalness={0.06}
+                            roughness={0.36}
+                        />
+                    </mesh>
+                    <mesh position={[0, innerHeight * 0.22, 0.48]}>
+                        <boxGeometry args={[innerWidth * 0.6, innerHeight * 0.022, 0.02]} />
+                        <meshStandardMaterial
+                            color="#09131d"
+                            emissive="#102030"
+                            emissiveIntensity={0.2}
+                            metalness={0.1}
+                            roughness={0.7}
+                        />
+                    </mesh>
+                </group>
+            ) : (
+                <mesh position={[0, 0, backWallZ]}>
+                    <planeGeometry args={[innerWidth * 0.64, innerHeight * 0.64]} />
+                    <meshStandardMaterial
+                        color="#07111b"
+                        emissive="#0d1b2a"
+                        emissiveIntensity={0.12}
+                        metalness={0.06}
+                        roughness={0.92}
+                        side={DoubleSide}
+                    />
+                </mesh>
+            )}
+        </group>
+    );
+}
+
+function RoundDockingTunnelInsert({
+    positionZ,
+    radius,
+    depth,
+}: {
+    positionZ: number;
+    radius: number;
+    depth: number;
+}): ReactElement {
+    return (
+        <group position={[0, 0, positionZ]}>
+            <mesh rotation={[Math.PI / 2, 0, 0]}>
+                <cylinderGeometry args={[radius, radius, depth, 24, 1, true]} />
+                <meshStandardMaterial
+                    color="#04080f"
+                    emissive="#08131d"
+                    emissiveIntensity={0.16}
+                    metalness={0.03}
+                    roughness={0.96}
+                    side={DoubleSide}
+                />
+            </mesh>
+            <mesh position={[0, 0, (depth / 2) - 0.04]}>
+                <circleGeometry args={[radius * 0.94, 24]} />
+                <meshStandardMaterial
+                    color="#02050a"
+                    emissive="#06101a"
+                    emissiveIntensity={0.06}
+                    metalness={0}
+                    roughness={1}
+                    side={DoubleSide}
+                />
+            </mesh>
+            <mesh position={[0, 0, (-depth / 2) + 0.02]}>
+                <circleGeometry args={[radius * 0.88, 24]} />
+                <meshStandardMaterial
+                    color="#02050a"
+                    emissive="#08111a"
+                    emissiveIntensity={0.08}
+                    metalness={0}
+                    roughness={1}
+                    transparent
+                    opacity={0.9}
+                    side={DoubleSide}
+                />
+            </mesh>
+        </group>
+    );
+}
+
+function CoriolisDockingMouthFrame(): ReactElement {
+    const mouthOuterWidth = 1.78;
+    const mouthOuterHeight = 1.32;
+    const mouthInnerWidth = 1.02;
+    const mouthInnerHeight = 0.76;
+    const collarDepth = 0.34;
+    const sidePanelWidth = (mouthOuterWidth - mouthInnerWidth) / 2;
+    const topPanelHeight = (mouthOuterHeight - mouthInnerHeight) / 2;
+    const sideOffsetX = (mouthInnerWidth / 2) + (sidePanelWidth / 2);
+    const topOffsetY = (mouthInnerHeight / 2) + (topPanelHeight / 2);
+    const guideColor = "#8fd3ff";
+
+    return (
+        <group position={[0, 0, 5.34]}>
+            <mesh position={[0, topOffsetY, 0]}>
+                <boxGeometry args={[mouthInnerWidth * 1.14, topPanelHeight, collarDepth]} />
+                <meshStandardMaterial
+                    color="#313a44"
+                    emissive="#111a25"
+                    emissiveIntensity={0.12}
+                    metalness={0.24}
+                    roughness={0.8}
+                />
+            </mesh>
+            <mesh position={[0, -topOffsetY, 0]}>
+                <boxGeometry args={[mouthInnerWidth * 1.14, topPanelHeight, collarDepth]} />
+                <meshStandardMaterial
+                    color="#313a44"
+                    emissive="#111a25"
+                    emissiveIntensity={0.12}
+                    metalness={0.24}
+                    roughness={0.8}
+                />
+            </mesh>
+            <mesh position={[-sideOffsetX, 0, 0]}>
+                <boxGeometry args={[sidePanelWidth, mouthInnerHeight * 1.14, collarDepth]} />
+                <meshStandardMaterial
+                    color="#313a44"
+                    emissive="#111a25"
+                    emissiveIntensity={0.12}
+                    metalness={0.24}
+                    roughness={0.8}
+                />
+            </mesh>
+            <mesh position={[sideOffsetX, 0, 0]}>
+                <boxGeometry args={[sidePanelWidth, mouthInnerHeight * 1.14, collarDepth]} />
+                <meshStandardMaterial
+                    color="#313a44"
+                    emissive="#111a25"
+                    emissiveIntensity={0.12}
+                    metalness={0.24}
+                    roughness={0.8}
+                />
+            </mesh>
+
+            <mesh position={[0, (mouthOuterHeight / 2) + 0.06, 0.12]} rotation={[-0.48, 0, 0]}>
+                <boxGeometry args={[mouthOuterWidth * 0.94, 0.14, 0.58]} />
+                <meshStandardMaterial
+                    color="#242c35"
+                    emissive="#0d151e"
+                    emissiveIntensity={0.08}
+                    metalness={0.2}
+                    roughness={0.84}
+                />
+            </mesh>
+            <mesh position={[0, -((mouthOuterHeight / 2) + 0.06), 0.12]} rotation={[0.48, 0, 0]}>
+                <boxGeometry args={[mouthOuterWidth * 0.94, 0.14, 0.58]} />
+                <meshStandardMaterial
+                    color="#242c35"
+                    emissive="#0d151e"
+                    emissiveIntensity={0.08}
+                    metalness={0.2}
+                    roughness={0.84}
+                />
+            </mesh>
+            <mesh position={[-((mouthOuterWidth / 2) + 0.06), 0, 0.12]} rotation={[0, 0.48, 0]}>
+                <boxGeometry args={[0.14, mouthOuterHeight * 0.92, 0.58]} />
+                <meshStandardMaterial
+                    color="#242c35"
+                    emissive="#0d151e"
+                    emissiveIntensity={0.08}
+                    metalness={0.2}
+                    roughness={0.84}
+                />
+            </mesh>
+            <mesh position={[(mouthOuterWidth / 2) + 0.06, 0, 0.12]} rotation={[0, -0.48, 0]}>
+                <boxGeometry args={[0.14, mouthOuterHeight * 0.92, 0.58]} />
+                <meshStandardMaterial
+                    color="#242c35"
+                    emissive="#0d151e"
+                    emissiveIntensity={0.08}
+                    metalness={0.2}
+                    roughness={0.84}
+                />
+            </mesh>
+
+            <mesh position={[0, (mouthInnerHeight / 2) + 0.02, 0.28]}>
+                <boxGeometry args={[mouthInnerWidth, 0.02, 0.02]} />
+                <meshStandardMaterial color={guideColor} emissive={guideColor} emissiveIntensity={0.72} />
+            </mesh>
+            <mesh position={[0, -((mouthInnerHeight / 2) + 0.02), 0.28]}>
+                <boxGeometry args={[mouthInnerWidth, 0.02, 0.02]} />
+                <meshStandardMaterial color={guideColor} emissive={guideColor} emissiveIntensity={0.72} />
+            </mesh>
+            <mesh position={[-((mouthInnerWidth / 2) + 0.02), 0, 0.28]}>
+                <boxGeometry args={[0.02, mouthInnerHeight, 0.02]} />
+                <meshStandardMaterial color={guideColor} emissive={guideColor} emissiveIntensity={0.72} />
+            </mesh>
+            <mesh position={[(mouthInnerWidth / 2) + 0.02, 0, 0.28]}>
+                <boxGeometry args={[0.02, mouthInnerHeight, 0.02]} />
+                <meshStandardMaterial color={guideColor} emissive={guideColor} emissiveIntensity={0.72} />
+            </mesh>
+        </group>
+    );
+}
+
+function CoriolisFrontHullShell(): ReactElement {
+    const shellCenterZ = 4.28;
+    const openingWidth = 1.72;
+    const openingHeight = 1.24;
+    const shellDepth = 0.72;
+    const shellColor = "#3a434d";
+    const ribColor = "#38414a";
+
+    return (
+        <group>
+            <mesh position={[0, 0.9, shellCenterZ]} rotation={[-0.62, 0, 0]}>
+                <boxGeometry args={[2.18, 0.3, shellDepth]} />
+                <meshStandardMaterial color={shellColor} metalness={0.16} roughness={0.82} />
+            </mesh>
+            <mesh position={[0, -0.9, shellCenterZ]} rotation={[0.62, 0, 0]}>
+                <boxGeometry args={[2.18, 0.3, shellDepth]} />
+                <meshStandardMaterial color={shellColor} metalness={0.16} roughness={0.82} />
+            </mesh>
+            <mesh position={[-1.1, 0, shellCenterZ]} rotation={[0, 0.62, 0]}>
+                <boxGeometry args={[0.3, 1.7, shellDepth]} />
+                <meshStandardMaterial color={shellColor} metalness={0.16} roughness={0.82} />
+            </mesh>
+            <mesh position={[1.1, 0, shellCenterZ]} rotation={[0, -0.62, 0]}>
+                <boxGeometry args={[0.3, 1.7, shellDepth]} />
+                <meshStandardMaterial color={shellColor} metalness={0.16} roughness={0.82} />
+            </mesh>
+
+            <mesh position={[0, 0, shellCenterZ + 0.04]}>
+                <boxGeometry args={[openingWidth, openingHeight, 0.14]} />
+                <meshStandardMaterial color="#202933" metalness={0.08} roughness={0.9} />
+            </mesh>
+            <mesh position={[0, 1.08, 3.9]} rotation={[-0.46, 0, 0]}>
+                <boxGeometry args={[2.28, 0.1, 0.44]} />
+                <meshStandardMaterial color={ribColor} metalness={0.1} roughness={0.86} />
+            </mesh>
+            <mesh position={[0, -1.08, 3.9]} rotation={[0.46, 0, 0]}>
+                <boxGeometry args={[2.28, 0.1, 0.44]} />
+                <meshStandardMaterial color={ribColor} metalness={0.1} roughness={0.86} />
+            </mesh>
+            <mesh position={[-1.24, 0, 3.9]} rotation={[0, 0.46, 0]}>
+                <boxGeometry args={[0.1, 1.98, 0.44]} />
+                <meshStandardMaterial color={ribColor} metalness={0.1} roughness={0.86} />
+            </mesh>
+            <mesh position={[1.24, 0, 3.9]} rotation={[0, -0.46, 0]}>
+                <boxGeometry args={[0.1, 1.98, 0.44]} />
+                <meshStandardMaterial color={ribColor} metalness={0.1} roughness={0.86} />
+            </mesh>
+        </group>
     );
 }
 
 function CoriolisStationModel(): ReactElement {
     return (
         <group>
-            <mesh rotation={[Math.PI / 4, 0, 0]}>
-                <octahedronGeometry args={[5.7, 0]} />
+            <mesh position={[0, 0, -2.08]}>
+                <octahedronGeometry args={[5.72, 0]} />
                 <meshStandardMaterial color="#b7bdc5" metalness={0.42} roughness={0.54} />
             </mesh>
 
-            <mesh position={[0, 0, 5.32]}>
-                <boxGeometry args={[1.2, 0.95, 0.44]} />
-                <meshStandardMaterial color="#3b424c" metalness={0.3} roughness={0.72} />
+            <CoriolisFrontHullShell />
+
+            <mesh position={[0, 0, -2.96]}>
+                <octahedronGeometry args={[4.92, 0]} />
+                <meshStandardMaterial
+                    color="#1d232b"
+                    emissive="#060b10"
+                    emissiveIntensity={0.08}
+                    metalness={0.2}
+                    roughness={0.9}
+                />
             </mesh>
 
-            <mesh position={[0, 0, 5.62]}>
-                <boxGeometry args={[0.72, 0.26, 0.14]} />
-                <meshStandardMaterial emissive="#4ac9ff" emissiveIntensity={0.8} metalness={0.22} roughness={0.22} />
-            </mesh>
+            <CoriolisDockingMouthFrame />
 
-            <mesh position={[-3.8, 0.2, 0]} rotation={[0, 0, Math.PI / 2]}>
-                <cylinderGeometry args={[0.18, 0.18, 2.2, 10]} />
-                <meshStandardMaterial metalness={0.46} roughness={0.44} />
-            </mesh>
-            <mesh position={[3.8, 0.2, 0]} rotation={[0, 0, Math.PI / 2]}>
-                <cylinderGeometry args={[0.18, 0.18, 2.2, 10]} />
-                <meshStandardMaterial metalness={0.46} roughness={0.44} />
-            </mesh>
+            <RectDockingTunnelInsert
+                positionZ={4.18}
+                outerWidth={1.72}
+                outerHeight={1.28}
+                innerWidth={1.04}
+                innerHeight={0.82}
+                depth={3.36}
+                guideLightColor="#82c8ff"
+                guideFrameCount={6}
+                showLandingPadTerminus
+            />
         </group>
     );
 }
@@ -605,6 +1279,12 @@ function OrbisStationModel(): ReactElement {
                 <cylinderGeometry args={[0.82, 0.82, 0.4, 24]} />
                 <meshStandardMaterial emissive="#5acfff" emissiveIntensity={0.68} metalness={0.22} roughness={0.24} />
             </mesh>
+
+            <RoundDockingTunnelInsert
+                positionZ={4.18}
+                radius={0.7}
+                depth={1.9}
+            />
         </group>
     );
 }
@@ -626,6 +1306,17 @@ function DefaultStationModel(): ReactElement {
                 <cylinderGeometry args={[0.62, 0.62, 0.3, 18]} />
                 <meshStandardMaterial emissive="#4ac9ff" emissiveIntensity={0.52} metalness={0.2} roughness={0.24} />
             </mesh>
+
+            <RectDockingTunnelInsert
+                positionZ={2.9}
+                outerWidth={0.8}
+                outerHeight={0.8}
+                innerWidth={0.5}
+                innerHeight={0.5}
+                depth={1.24}
+                guideLightColor="#7fc7ff"
+                guideFrameCount={4}
+            />
         </group>
     );
 }
@@ -644,7 +1335,7 @@ function StationModel({
 }): ReactElement {
     const position = sceneAnchorPosition(contact);
     const shape = resolveStationShapeKey(contact.station_archetype_shape);
-    const distanceScale = stationDistanceScale(contact.distance_km);
+    const distanceScale = resolveStationRenderScale(contact);
     if (shape === "coriolis") {
         return (
             <group
@@ -680,7 +1371,7 @@ function StationModel({
 
 function resolveStationCollisionRadiusKm(contact: ScannerAnchorContact): number {
     const shape = resolveStationShapeKey(contact.station_archetype_shape);
-    const scaledRadius = (resolveStationBaseRadius(shape) * stationDistanceScale(contact.distance_km)) + 0.08;
+    const scaledRadius = (resolveStationBaseRadius(shape) * resolveStationRenderScale(contact)) + 0.08;
     return Math.max(0.22, scaledRadius);
 }
 
@@ -928,6 +1619,7 @@ function FlightTransitScene({
 function FlightSceneContent({
     jumpPhase,
     renderProfile,
+    cameraMode = "boresight",
     shipVisualKey,
     focusedContact,
     scannerContacts,
@@ -940,6 +1632,8 @@ function FlightSceneContent({
     waypointContactId,
     onDockingApproachProgress,
     onDockingApproachComplete,
+    onDockingDebug,
+    dockingRotationMatchEnabled,
     showContactLabels,
     spawnDirective,
     onSpawnDirectiveApplied,
@@ -947,10 +1641,11 @@ function FlightSceneContent({
 }: {
     jumpPhase: FlightSceneProps["jumpPhase"];
     renderProfile: FlightSceneProps["renderProfile"];
+    cameraMode?: FlightCameraMode;
     shipVisualKey?: string | null;
     focusedContact: ScannerAnchorContact | null;
     scannerContacts: ScannerAnchorContact[];
-    celestialAnchors: ScannerAnchorContact[];
+    celestialAnchors: CelestialPresentationAnchor[];
     onSpeedChange?: (speed: number) => void;
     onRollChange?: (rollDegrees: number) => void;
     onScannerTelemetryChange?: (contacts: ScannerTelemetryContact[]) => void;
@@ -964,6 +1659,8 @@ function FlightSceneContent({
         stage: DockingApproachStage;
     }) => void;
     onDockingApproachComplete?: () => void;
+    onDockingDebug?: (payload: DockingDebugPayload) => void;
+    dockingRotationMatchEnabled?: boolean;
     showContactLabels?: boolean;
     spawnDirective?: FlightSceneSpawnDirective | null;
     onSpawnDirectiveApplied?: (nonce: number) => void;
@@ -993,8 +1690,25 @@ function FlightSceneContent({
     const pitchRef = useRef(0);
     const rollRef = useRef(0);
     const forwardVectorRef = useRef(new Vector3(0, 0, 1));
-    const cockpitOffsetRef = useRef(new Vector3(0, 0.2, 0.18));
+    const flightCameraCockpitOffsetRef = useRef(new Vector3(0, 0.2, 0.18));
+    const flightCameraBoresightOffsetRef = useRef(new Vector3(0, 0, 0));
+    const dockingCameraDockingOffsetRef = useRef(new Vector3(0, 0, 0));
     const cockpitWorldOffsetRef = useRef(new Vector3());
+    const dockingCameraPresentationOffsetRef = useRef(
+        cameraMode === "cockpit"
+            ? new Vector3(0, 0.2, 0.18)
+            : new Vector3(0, 0, 0),
+    );
+    const cameraOffsetBlendRef = useRef(
+        cameraMode === "cockpit"
+            ? new Vector3(0, 0.2, 0.18)
+            : new Vector3(0, 0, 0),
+    );
+    const cameraOffsetTargetRef = useRef(
+        cameraMode === "cockpit"
+            ? new Vector3(0, 0.2, 0.18)
+            : new Vector3(0, 0, 0),
+    );
     const scannerRelativeVectorRef = useRef(new Vector3());
     const scannerCameraRelativeVectorRef = useRef(new Vector3());
     const scannerInverseQuaternionRef = useRef(new Quaternion());
@@ -1009,9 +1723,14 @@ function FlightSceneContent({
     const dockingApproachLastTargetIdRef = useRef<string | null>(null);
     const dockingApproachStageStartedAtRef = useRef(0);
     const dockingHoldAlignAlignedSinceRef = useRef(0);
+    const dockingFinalReacquireLastAtRef = useRef(0);
+    const dockingLastResetAtRef = useRef(0);
+    const dockingRotationMatchLatchedRef = useRef(false);
     const dockingApproachPortCorePositionRef = useRef(new Vector3());
     const dockingApproachPortPositionRef = useRef(new Vector3());
+    const dockingApproachTunnelEntryPositionRef = useRef(new Vector3());
     const dockingApproachHoldPointRef = useRef(new Vector3());
+    const dockingApproachStationCenterRef = useRef(new Vector3());
     const dockingApproachEntryVectorRef = useRef(new Vector3(0, 0, 1));
     const dockingDesiredVectorRef = useRef(new Vector3());
     const dockingAimDirectionRef = useRef(new Vector3());
@@ -1019,15 +1738,25 @@ function FlightSceneContent({
     const dockingTemporaryVectorRef = useRef(new Vector3());
     const dockingCameraAimPositionRef = useRef(new Vector3());
     const dockingCameraToPortRef = useRef(new Vector3());
+    const dockingPortCameraSpaceRef = useRef(new Vector3());
     const dockingForwardVectorRef = useRef(new Vector3(0, 0, -1));
     const dockingShipToPortDirectionRef = useRef(new Vector3(0, 0, -1));
+    const dockingAlignmentDirectionRef = useRef(new Vector3(0, 0, -1));
     const dockingFilteredAimDirectionRef = useRef(new Vector3(0, 0, -1));
     const dockingVelocityTargetDirectionRef = useRef(new Vector3(0, 0, -1));
     const dockingVelocityParallelRef = useRef(new Vector3());
     const dockingVelocityLateralRef = useRef(new Vector3());
     const dockingOrientationEulerRef = useRef(new Euler(0, 0, 0, "YXZ"));
-    const dockingOrientationQuaternionRef = useRef(new Quaternion());
+    const dockingCameraOffsetQuaternionRef = useRef(new Quaternion());
+    const dockingCameraQuaternionRef = useRef(new Quaternion());
+    const dockingCameraInverseQuaternionRef = useRef(new Quaternion());
     const spawnDirectiveAppliedNonceRef = useRef<number | null>(null);
+    const lastDockingDebugTelemetryAtRef = useRef(0);
+    const lastDockingDebugContactMissingAtRef = useRef(0);
+    const dockingCameraPresentationTargetRef = useRef(0);
+    const dockingCameraPresentationBlendRef = useRef(0);
+    const dockingCameraTargetFovRef = useRef(62);
+    const dockingCameraTargetNearRef = useRef(0.1);
 
     const SCANNER_PLANE_RANGE = 110;
     const SCANNER_ALTITUDE_RANGE = 48;
@@ -1046,14 +1775,34 @@ function FlightSceneContent({
     const DOCKING_HOLD_ALIGN_TIMEOUT_REQUIRED_COSINE = Math.cos((14 * Math.PI) / 180);
     const DOCKING_HOLD_ALIGN_CORRIDOR_TOLERANCE_KM = 0.22;
     const DOCKING_HOLD_ALIGN_TIMEOUT_CORRIDOR_TOLERANCE_KM = 0.34;
+    const DOCKING_HOLD_ALIGN_TIMEOUT_MAX_DISTANCE_KM = 1.15;
+    const DOCKING_HOLD_ALIGN_RESET_ALIGNMENT_COSINE = Math.cos((58 * Math.PI) / 180);
+    const DOCKING_HOLD_ALIGN_RESET_CORRIDOR_MIN_KM = 0.16;
+    const DOCKING_HOLD_ALIGN_RESET_TIMEOUT_MS = 4200;
+    const DOCKING_HOLD_ALIGN_RESET_COOLDOWN_MS = 2200;
+    const DOCKING_HOLD_ALIGN_FINAL_ENTRY_MAX_DISTANCE_KM = 0.82;
     const DOCKING_HOLD_ALIGN_STABLE_MS = 650;
-    const DOCKING_HOLD_ALIGN_MAX_SPEED = 0.12;
+    const DOCKING_HOLD_ALIGN_MAX_SPEED = 0.08;
+    const DOCKING_HOLD_ALIGN_RECOVERY_MAX_SPEED = 0.055;
+    const DOCKING_TUNNEL_ENTRY_TARGET_OFFSET_KM = 0.22;
+    const DOCKING_TUNNEL_ENTRY_FINAL_TRIGGER_KM = 0.18;
+    const DOCKING_TUNNEL_ENTRY_MIN_DURATION_MS = 550;
+    const DOCKING_TUNNEL_ENTRY_MIN_SPEED = 0.03;
+    const DOCKING_TUNNEL_ENTRY_MAX_SPEED = 0.11;
+    const DOCKING_TUNNEL_ENTRY_ACCELERATION = 0.66;
+    const DOCKING_HOLD_ENTRY_ALIGN_COSINE = Math.cos((36 * Math.PI) / 180);
+    const DOCKING_HOLD_ENTRY_CORRIDOR_TOLERANCE_KM = 0.18;
+    const DOCKING_HOLD_ENTRY_NEAR_PORT_SPEED = 0.24;
+    const DOCKING_HOLD_ENTRY_NEAR_PORT_DISTANCE_KM = 2.2;
+    const DOCKING_HOLD_ENTRY_ACCELERATION = 0.95;
+    const DOCKING_HOLD_ALIGN_ACCELERATION = 0.6;
+    const DOCKING_FINAL_APPROACH_ACCELERATION = 0.72;
     const DOCKING_HOLD_ENTRY_TURN_RAMP_MS = 1650;
     const DOCKING_HOLD_ENTRY_INITIAL_YAW_RATE = 0.62;
     const DOCKING_HOLD_ENTRY_INITIAL_PITCH_RATE = 0.48;
     const DOCKING_FINAL_MIN_SPEED = 0.08;
-    const DOCKING_FINAL_CLOSE_MIN_SPEED = 0.025;
     const DOCKING_FINAL_MAX_SPEED = 0.35;
+    const DOCKING_FINAL_CLOSE_MIN_SPEED = 0.025;
     const DOCKING_FINAL_CLOSE_RANGE_KM = 0.55;
     const DOCKING_FINAL_CLOSE_BRAKE_FACTOR = 0.32;
     const DOCKING_FINAL_CLOSE_ACCELERATION = 1.9;
@@ -1065,16 +1814,63 @@ function FlightSceneContent({
     const DOCKING_FINAL_CAPTURE_ACCELERATION = 0.7;
     const DOCKING_FINAL_CAPTURE_YAW_RATE = 1.45;
     const DOCKING_FINAL_CAPTURE_PITCH_RATE = 1.15;
-    const DOCKING_FINAL_CAPTURE_ALIGNMENT_COSINE = Math.cos((7 * Math.PI) / 180);
+    const DOCKING_FALLBACK_ALIGNMENT_COSINE = Math.cos((20 * Math.PI) / 180);
+    const DOCKING_FALLBACK_CORRIDOR_MAX_KM = 0.11;
+    const DOCKING_FINAL_HARD_LOCK_THRESHOLD = 0.14;
+    const DOCKING_FINAL_HARD_LOCK_ALIGNMENT_COSINE = Math.cos((10 * Math.PI) / 180);
+    const DOCKING_FINAL_INSIDE_PORT_THRESHOLD_KM = 0.11;
+    const DOCKING_FINAL_INSIDE_PORT_CORRIDOR_MAX_KM = 0.05;
+    const DOCKING_FINAL_INSIDE_PORT_APPROACH_MAX_KM = 0.09;
+    const DOCKING_FINAL_INSIDE_PORT_MAX_SPEED = 0.05;
+    const DOCKING_FINAL_NEAR_PORT_THRESHOLD_KM = 0.115;
+    const DOCKING_FINAL_NEAR_PORT_CORRIDOR_MAX_KM = 0.03;
+    const DOCKING_FINAL_NEAR_PORT_APPROACH_MAX_KM = 0.055;
+    const DOCKING_FINAL_NEAR_PORT_MAX_SPEED = 0.04;
+    const DOCKING_DIRECT_PORT_ALIGNMENT_COSINE = Math.cos((4 * Math.PI) / 180);
+    const DOCKING_DIRECT_PORT_CORRIDOR_MAX_KM = 0.026;
+    const DOCKING_DIRECT_PORT_APPROACH_MAX_KM = 0.062;
+    const DOCKING_DIRECT_PORT_MAX_SPEED = 0.05;
+    const DOCKING_COMPLETE_MIN_TUNNEL_PENETRATION_KM = 0.32;
+    const DOCKING_COMPLETE_STRICT_TUNNEL_PENETRATION_KM = 0.36;
+    const DOCKING_COMPLETE_SCREEN_CENTER_MAX_X = 0.72;
+    const DOCKING_COMPLETE_SCREEN_CENTER_MAX_Y = 0.66;
+    const DOCKING_COMPLETE_SCREEN_STRICT_CENTER_MAX_X = 0.52;
+    const DOCKING_COMPLETE_SCREEN_STRICT_CENTER_MAX_Y = 0.48;
+    const DOCKING_PORT_ROTATION_MATCH_RANGE_KM = 2.0;
+    const DOCKING_ROTATION_MATCH_MAX_DISTANCE_KM = 2.0;
+    const DOCKING_ROTATION_MATCH_ROLL_RATE = 3.2;
+    const DOCKING_ROTATION_MATCH_HOLD_ALIGN_ALIGNMENT_COSINE = Math.cos((70 * Math.PI) / 180);
+    const DOCKING_ROTATION_MATCH_FINAL_ALIGNMENT_COSINE = Math.cos((28 * Math.PI) / 180);
+    const DOCKING_ROTATION_MATCH_HOLD_ALIGN_CORRIDOR_MAX_KM = 0.34;
+    const DOCKING_ROTATION_MATCH_FINAL_CORRIDOR_MAX_KM = 0.08;
+    const DOCKING_ROTATION_MATCH_FINAL_DISTANCE_KM = 0.24;
+    const DOCKING_ROTATION_MATCH_RELEASE_ALIGNMENT_COSINE = Math.cos((56 * Math.PI) / 180);
+    const DOCKING_ROTATION_MATCH_RELEASE_CORRIDOR_MAX_KM = 0.14;
+    const DOCKING_ROTATION_MATCH_RELEASE_FINAL_CORRIDOR_MAX_KM = 0.1;
+    const DOCKING_FINAL_RECOVERY_ALIGNMENT_COSINE = Math.cos((34 * Math.PI) / 180);
+    const DOCKING_FINAL_RECOVERY_MAX_SPEED = 0.045;
+    const DOCKING_FINAL_RECOVERY_CORRIDOR_MAX_KM = 0.26;
+    const DOCKING_FINAL_REACQUIRE_ALIGNMENT_COSINE = Math.cos((68 * Math.PI) / 180);
+    const DOCKING_FINAL_REACQUIRE_CORRIDOR_MIN_KM = 0.18;
+    const DOCKING_FINAL_REACQUIRE_MIN_DISTANCE_KM = 0.2;
+    const DOCKING_FINAL_REACQUIRE_MIN_ELAPSED_MS = 850;
+    const DOCKING_FINAL_REACQUIRE_COOLDOWN_MS = 1600;
+    const DOCKING_RESET_HOLD_DISTANCE_MIN = 1.35;
+    const DOCKING_RESET_HOLD_DISTANCE_MAX = 2.2;
     const DOCKING_RETICLE_LOCK_RANGE_KM = 0.8;
     const DOCKING_RETICLE_EARLY_LOCK_RANGE_KM = 3.2;
     const DOCKING_RETICLE_HOLD_ENTRY_BLEND = 0.72;
     const DOCKING_RETICLE_HOLD_ALIGN_BLEND = 0.92;
     const DOCKING_RETICLE_HARD_LOCK_BLEND = 0.92;
+    const DOCKING_RETICLE_ALIGNMENT_BLEND_RANGE_KM = 0.7;
+    const DOCKING_RETICLE_CAMERA_BIAS_HOLD_ALIGN = 0.58;
+    const DOCKING_RETICLE_CAMERA_BIAS_FINAL = 0.34;
+    const DOCKING_RETICLE_CAMERA_BIAS_CAPTURE = 0.2;
     const DOCKING_AVOIDANCE_RADIUS = 2.35;
     const DOCKING_FINAL_STAGE_MIN_DURATION_MS = 4200;
     const DOCKING_FINAL_STAGE_FORCE_COMPLETE_MS = 12000;
     const DOCKING_UNDOCK_EXIT_FORWARD_SPEED = 0.78;
+    const DOCKING_TRAJECTORY_AIM_BLEND_HOLD_ENTRY = 0.22;
     const DOCKING_TRAJECTORY_AIM_BLEND_HOLD_ALIGN = 0.64;
     const DOCKING_TRAJECTORY_AIM_BLEND_FINAL = 0.82;
     const DOCKING_TRAJECTORY_AIM_BLEND_CAPTURE = 0.92;
@@ -1085,6 +1881,80 @@ function FlightSceneContent({
     const DOCKING_AIM_SMOOTH_RATE_HOLD_ALIGN = 2.3;
     const DOCKING_AIM_SMOOTH_RATE_FINAL = 2.8;
     const DOCKING_AIM_SMOOTH_RATE_CAPTURE = 4.1;
+    const FLIGHT_CAMERA_BASE_FOV = 62;
+    const FLIGHT_CAMERA_BASE_NEAR = 0.1;
+    const DOCKING_CAMERA_HOLD_ALIGN_FOV = 48;
+    const DOCKING_CAMERA_FINAL_FOV = 32;
+    const DOCKING_CAMERA_CAPTURE_FOV = 20;
+    const DOCKING_CAMERA_HOLD_ALIGN_NEAR = 0.05;
+    const DOCKING_CAMERA_FINAL_NEAR = 0.02;
+    const DOCKING_CAMERA_CAPTURE_NEAR = 0.008;
+    const DOCKING_CAMERA_PRESENTATION_RANGE_KM = 1.4;
+    const DOCKING_CAMERA_BLEND_SMOOTH_RATE = 2.8;
+    const DOCKING_CAMERA_FOV_SMOOTH_RATE = 3.8;
+    const dockingStageTransitionConfig = {
+        holdPointThresholdKm: DOCKING_HOLD_POINT_THRESHOLD,
+        holdEntryMinDurationMs: DOCKING_HOLD_ENTRY_MIN_DURATION_MS,
+        holdEntryAlignCosine: DOCKING_HOLD_ENTRY_ALIGN_COSINE,
+        holdEntryCorridorToleranceKm: DOCKING_HOLD_ENTRY_CORRIDOR_TOLERANCE_KM,
+        holdAlignRequiredCosine: DOCKING_HOLD_ALIGN_REQUIRED_COSINE,
+        holdAlignCorridorToleranceKm: DOCKING_HOLD_ALIGN_CORRIDOR_TOLERANCE_KM,
+        holdAlignDurationMs: DOCKING_HOLD_ALIGN_DURATION_MS,
+        holdAlignStableMs: DOCKING_HOLD_ALIGN_STABLE_MS,
+        holdAlignMaxDurationMs: DOCKING_HOLD_ALIGN_MAX_DURATION_MS,
+        holdAlignTimeoutRequiredCosine: DOCKING_HOLD_ALIGN_TIMEOUT_REQUIRED_COSINE,
+        holdAlignTimeoutCorridorToleranceKm: DOCKING_HOLD_ALIGN_TIMEOUT_CORRIDOR_TOLERANCE_KM,
+        holdAlignTimeoutMaxDistanceKm: DOCKING_HOLD_ALIGN_TIMEOUT_MAX_DISTANCE_KM,
+        holdAlignFinalEntryMaxDistanceKm: DOCKING_HOLD_ALIGN_FINAL_ENTRY_MAX_DISTANCE_KM,
+        holdAlignResetAlignmentCosine: DOCKING_HOLD_ALIGN_RESET_ALIGNMENT_COSINE,
+        holdAlignResetCorridorMinKm: DOCKING_HOLD_ALIGN_RESET_CORRIDOR_MIN_KM,
+        holdAlignResetTimeoutMs: DOCKING_HOLD_ALIGN_RESET_TIMEOUT_MS,
+        holdAlignResetCooldownMs: DOCKING_HOLD_ALIGN_RESET_COOLDOWN_MS,
+        tunnelEntryMinDurationMs: DOCKING_TUNNEL_ENTRY_MIN_DURATION_MS,
+        tunnelEntryFinalTriggerKm: DOCKING_TUNNEL_ENTRY_FINAL_TRIGGER_KM,
+        finalHardLockAlignmentCosine: DOCKING_FINAL_HARD_LOCK_ALIGNMENT_COSINE,
+        finalInsidePortCorridorMaxKm: DOCKING_FINAL_INSIDE_PORT_CORRIDOR_MAX_KM,
+        finalReacquireMinElapsedMs: DOCKING_FINAL_REACQUIRE_MIN_ELAPSED_MS,
+        finalReacquireCooldownMs: DOCKING_FINAL_REACQUIRE_COOLDOWN_MS,
+        finalReacquireMinDistanceKm: DOCKING_FINAL_REACQUIRE_MIN_DISTANCE_KM,
+        finalReacquireAlignmentCosine: DOCKING_FINAL_REACQUIRE_ALIGNMENT_COSINE,
+        finalReacquireCorridorMinKm: DOCKING_FINAL_REACQUIRE_CORRIDOR_MIN_KM,
+    };
+    const dockingCompletionConfig = {
+        finalHardLockThresholdKm: DOCKING_FINAL_HARD_LOCK_THRESHOLD,
+        completeMinTunnelPenetrationKm: DOCKING_COMPLETE_MIN_TUNNEL_PENETRATION_KM,
+        finalHardLockAlignmentCosine: DOCKING_FINAL_HARD_LOCK_ALIGNMENT_COSINE,
+        finalInsidePortCorridorMaxKm: DOCKING_FINAL_INSIDE_PORT_CORRIDOR_MAX_KM,
+        finalInsidePortMaxSpeed: DOCKING_FINAL_INSIDE_PORT_MAX_SPEED,
+        finalInsidePortThresholdKm: DOCKING_FINAL_INSIDE_PORT_THRESHOLD_KM,
+        completeStrictTunnelPenetrationKm: DOCKING_COMPLETE_STRICT_TUNNEL_PENETRATION_KM,
+        finalInsidePortApproachMaxKm: DOCKING_FINAL_INSIDE_PORT_APPROACH_MAX_KM,
+        finalNearPortThresholdKm: DOCKING_FINAL_NEAR_PORT_THRESHOLD_KM,
+        finalNearPortApproachMaxKm: DOCKING_FINAL_NEAR_PORT_APPROACH_MAX_KM,
+        finalNearPortCorridorMaxKm: DOCKING_FINAL_NEAR_PORT_CORRIDOR_MAX_KM,
+        finalNearPortMaxSpeed: DOCKING_FINAL_NEAR_PORT_MAX_SPEED,
+        finalStageMinDurationMs: DOCKING_FINAL_STAGE_MIN_DURATION_MS,
+        portThresholdKm: DOCKING_PORT_THRESHOLD,
+        directPortAlignmentCosine: DOCKING_DIRECT_PORT_ALIGNMENT_COSINE,
+        directPortCorridorMaxKm: DOCKING_DIRECT_PORT_CORRIDOR_MAX_KM,
+        directPortApproachMaxKm: DOCKING_DIRECT_PORT_APPROACH_MAX_KM,
+        directPortMaxSpeed: DOCKING_DIRECT_PORT_MAX_SPEED,
+        finalStageForceCompleteMs: DOCKING_FINAL_STAGE_FORCE_COMPLETE_MS,
+        portFallbackThresholdKm: DOCKING_PORT_FALLBACK_THRESHOLD,
+        fallbackAlignmentCosine: DOCKING_FALLBACK_ALIGNMENT_COSINE,
+        fallbackCorridorMaxKm: DOCKING_FALLBACK_CORRIDOR_MAX_KM,
+    };
+    const dockingRotationMatchConfig = {
+        rotationMatchMaxDistanceKm: DOCKING_ROTATION_MATCH_MAX_DISTANCE_KM,
+        rotationMatchFinalDistanceKm: DOCKING_ROTATION_MATCH_FINAL_DISTANCE_KM,
+        rotationMatchHoldAlignAlignmentCosine: DOCKING_ROTATION_MATCH_HOLD_ALIGN_ALIGNMENT_COSINE,
+        rotationMatchFinalAlignmentCosine: DOCKING_ROTATION_MATCH_FINAL_ALIGNMENT_COSINE,
+        rotationMatchHoldAlignCorridorMaxKm: DOCKING_ROTATION_MATCH_HOLD_ALIGN_CORRIDOR_MAX_KM,
+        rotationMatchFinalCorridorMaxKm: DOCKING_ROTATION_MATCH_FINAL_CORRIDOR_MAX_KM,
+        rotationMatchReleaseAlignmentCosine: DOCKING_ROTATION_MATCH_RELEASE_ALIGNMENT_COSINE,
+        rotationMatchReleaseCorridorMaxKm: DOCKING_ROTATION_MATCH_RELEASE_CORRIDOR_MAX_KM,
+        rotationMatchReleaseFinalCorridorMaxKm: DOCKING_ROTATION_MATCH_RELEASE_FINAL_CORRIDOR_MAX_KM,
+    };
 
     const starCount = renderProfile === "performance"
         ? 160
@@ -1155,15 +2025,36 @@ function FlightSceneContent({
         return scannerContacts.find((contact) => contact.id === dockingApproachContactId) ?? null;
     }, [dockingApproachContactId, scannerContacts]);
 
+    const celestialAnchorById = useMemo(
+        () => new Map(celestialAnchors.map((anchor) => [anchor.id, anchor])),
+        [celestialAnchors],
+    );
+
+    const waypointTargetId = dockingApproachTargetContact?.id ?? waypointContactId ?? null;
+
     const waypointTargetContact = useMemo(() => {
         if (dockingApproachTargetContact) {
             return dockingApproachTargetContact;
         }
-        if (!waypointContactId) {
+        if (!waypointTargetId) {
             return null;
         }
-        return scannerContacts.find((contact) => contact.id === waypointContactId) ?? null;
-    }, [dockingApproachTargetContact, scannerContacts, waypointContactId]);
+        return scannerContacts.find((contact) => contact.id === waypointTargetId) ?? null;
+    }, [dockingApproachTargetContact, scannerContacts, waypointTargetId]);
+
+    const waypointTargetCelestialAnchor = useMemo(() => {
+        if (!waypointTargetId || dockingApproachTargetContact) {
+            return null;
+        }
+        return celestialAnchorById.get(waypointTargetId) ?? null;
+    }, [celestialAnchorById, dockingApproachTargetContact, waypointTargetId]);
+
+    const focusedContactCelestialAnchor = useMemo(() => {
+        if (!focusedContact) {
+            return null;
+        }
+        return celestialAnchorById.get(focusedContact.id) ?? null;
+    }, [celestialAnchorById, focusedContact]);
 
     useEffect(() => {
         dockingApproachInitialDistanceRef.current = null;
@@ -1173,6 +2064,9 @@ function FlightSceneContent({
         dockingApproachLastTargetIdRef.current = null;
         dockingApproachStageStartedAtRef.current = 0;
         dockingHoldAlignAlignedSinceRef.current = 0;
+        dockingFinalReacquireLastAtRef.current = 0;
+        dockingLastResetAtRef.current = 0;
+        dockingRotationMatchLatchedRef.current = false;
     }, [dockingApproachContactId]);
 
     useEffect(() => {
@@ -1195,10 +2089,11 @@ function FlightSceneContent({
             return;
         }
 
+        const [stationX, stationY, stationZ] = sceneAnchorPosition(stationContact);
         const directionAwayFromStation = dockingTemporaryVectorRef.current.set(
-            -stationContact.scene_x,
-            -stationContact.scene_y,
-            -stationContact.scene_z,
+            -stationX,
+            -stationY,
+            -stationZ,
         );
         if (directionAwayFromStation.lengthSq() <= 0.000001) {
             directionAwayFromStation.set(0, 0, 1);
@@ -1235,39 +2130,42 @@ function FlightSceneContent({
     ]);
 
     const waypointPosition = useMemo<[number, number, number] | null>(() => {
-        if (!waypointTargetContact) {
+        if (waypointTargetContact) {
+            return resolveContactMarkerPosition(
+                waypointTargetContact,
+                celestialAnchorById.get(waypointTargetContact.id) ?? null,
+            );
+        }
+        if (!waypointTargetCelestialAnchor) {
             return null;
         }
-        return [
-            waypointTargetContact.scene_x,
-            waypointTargetContact.scene_y,
-            waypointTargetContact.scene_z,
-        ];
-    }, [waypointTargetContact]);
+        return celestialAnchorPosition(waypointTargetCelestialAnchor);
+    }, [celestialAnchorById, waypointTargetCelestialAnchor, waypointTargetContact]);
 
     const focusedContactPosition = useMemo<[number, number, number] | null>(() => {
         if (!focusedContact) {
             return null;
         }
-        return [
-            focusedContact.scene_x,
-            focusedContact.scene_y,
-            focusedContact.scene_z,
-        ];
-    }, [focusedContact]);
+        return resolveContactMarkerPosition(focusedContact, focusedContactCelestialAnchor);
+    }, [focusedContact, focusedContactCelestialAnchor]);
 
     const showFocusedContactIndicator = Boolean(
         focusedContactPosition
         && focusedContact?.id
-        && focusedContact.id !== waypointTargetContact?.id,
+        && focusedContact.id !== waypointTargetId,
     );
 
-    const showWaypointIndicator = (
-        jumpPhase === "destination-locked"
-        || jumpPhase === "charging"
-        || jumpPhase === "jumping"
-        || jumpPhase === "docking-approach"
-    );
+    const waypointIndicatorScale = useMemo(() => {
+        if (waypointTargetContact?.contact_type === "station") {
+            return resolveStationCollisionRadiusKm(waypointTargetContact) + 1.2;
+        }
+        if (waypointTargetCelestialAnchor) {
+            return resolveCelestialAnchorSize(waypointTargetCelestialAnchor) + 1.1;
+        }
+        return 1.8;
+    }, [waypointTargetCelestialAnchor, waypointTargetContact]);
+
+    const showWaypointIndicator = Boolean(waypointPosition && waypointTargetId);
 
     const trafficCount = COBRA_TRAFFIC_LOD_BUDGET_BY_PROFILE[renderProfile];
 
@@ -1280,7 +2178,6 @@ function FlightSceneContent({
 
     const visibleCelestialAnchors = useMemo(
         () => celestialAnchors
-            .filter((contact) => contact.contact_type !== "station")
             .sort((left, right) => left.distance_km - right.distance_km)
             .slice(0, CELESTIAL_LOD_BUDGET_BY_PROFILE[renderProfile]),
         [celestialAnchors, renderProfile],
@@ -1407,10 +2304,24 @@ function FlightSceneContent({
             return;
         }
 
+        const dockingApproachRequested = Boolean(dockingApproachContactId);
         const isDockingApproachActive = Boolean(
             dockingApproachContactId
             && dockingApproachTargetContact,
         );
+
+        if (dockingApproachRequested && !isDockingApproachActive && onDockingDebug) {
+            const nowMs = performance.now();
+            if (nowMs - lastDockingDebugContactMissingAtRef.current >= 1000) {
+                lastDockingDebugContactMissingAtRef.current = nowMs;
+                onDockingDebug({
+                    event: "contact-missing",
+                    jumpPhase,
+                    contactId: dockingApproachContactId ?? "unknown",
+                    reason: "docking-target-contact-not-in-scanner-feed",
+                });
+            }
+        }
 
         const input = inputRef.current;
         if (isDockingApproachActive && dockingApproachTargetContact) {
@@ -1418,14 +2329,14 @@ function FlightSceneContent({
             const stationCollisionRadiusKm = resolveStationCollisionRadiusKm(
                 dockingApproachTargetContact,
             );
-            const stationCenter = dockingTemporaryVectorRef.current.set(
-                dockingApproachTargetContact.scene_x,
-                dockingApproachTargetContact.scene_y,
-                dockingApproachTargetContact.scene_z,
+            const stationCenter = resolveContactRenderPosition(
+                dockingApproachTargetContact,
+                dockingApproachStationCenterRef.current,
             );
             const portCorePosition = resolveDockingPortWorldPosition(
                 dockingApproachTargetContact,
                 dockingApproachPortCorePositionRef.current,
+                state.clock.elapsedTime,
             );
             const entryVector = dockingApproachEntryVectorRef.current
                 .copy(portCorePosition)
@@ -1443,12 +2354,23 @@ function FlightSceneContent({
             const portPosition = dockingApproachPortPositionRef.current
                 .copy(portCorePosition)
                 .addScaledVector(entryVector, portStandoffKm);
+            const tunnelEntryPosition = dockingApproachTunnelEntryPositionRef.current
+                .copy(portCorePosition)
+                .addScaledVector(entryVector, -DOCKING_TUNNEL_ENTRY_TARGET_OFFSET_KM);
 
             if (dockingApproachLastTargetIdRef.current !== approachTargetId) {
                 dockingApproachLastTargetIdRef.current = approachTargetId;
                 dockingApproachStageRef.current = "hold-entry";
                 dockingApproachStageStartedAtRef.current = performance.now();
                 dockingHoldAlignAlignedSinceRef.current = 0;
+
+                onDockingDebug?.({
+                    event: "target-acquired",
+                    jumpPhase,
+                    contactId: approachTargetId,
+                    targetName: dockingApproachTargetContact.name,
+                    stage: "hold-entry",
+                });
 
                 const holdDistance = DOCKING_HOLD_DISTANCE_MIN
                     + (Math.random() * (DOCKING_HOLD_DISTANCE_MAX - DOCKING_HOLD_DISTANCE_MIN));
@@ -1474,28 +2396,54 @@ function FlightSceneContent({
                 );
             }
 
-            if (dockingApproachStageRef.current === "hold-entry") {
-                const holdDistanceRemaining = ship.position.distanceTo(
-                    dockingApproachHoldPointRef.current,
-                );
-                const holdEntryElapsedMs = performance.now() - dockingApproachStageStartedAtRef.current;
-                if (
-                    holdDistanceRemaining <= DOCKING_HOLD_POINT_THRESHOLD
-                    && holdEntryElapsedMs >= DOCKING_HOLD_ENTRY_MIN_DURATION_MS
-                ) {
-                    dockingApproachStageRef.current = "hold-align";
-                    dockingApproachStageStartedAtRef.current = performance.now();
-                    dockingHoldAlignAlignedSinceRef.current = 0;
-                }
-            }
+            const holdEntryDistanceRemaining = dockingApproachStageRef.current === "hold-entry"
+                ? ship.position.distanceTo(dockingApproachHoldPointRef.current)
+                : Number.POSITIVE_INFINITY;
 
-            const activeApproachStage = dockingApproachStageRef.current;
-            const stageTarget = activeApproachStage === "final-approach"
-                ? portPosition
-                : dockingApproachHoldPointRef.current;
-            const stageDistanceRemaining = ship.position.distanceTo(stageTarget);
             const distanceToPort = ship.position.distanceTo(portCorePosition);
             const distanceToApproachPoint = ship.position.distanceTo(portPosition);
+            const tunnelPenetrationDepthKm = Math.max(
+                0,
+                -dockingTemporaryVectorRef.current
+                    .copy(ship.position)
+                    .sub(portPosition)
+                    .dot(entryVector),
+            );
+            const activeApproachStage = dockingApproachStageRef.current;
+            const dockingCameraPresentationBlend = calculateDockingCameraPresentationBlend({
+                stage: activeApproachStage,
+                distanceToPortKm: distanceToPort,
+                presentationRangeKm: DOCKING_CAMERA_PRESENTATION_RANGE_KM,
+            });
+            dockingCameraPresentationTargetRef.current = dockingCameraPresentationBlend;
+            const baseFlightCameraOffset = cameraMode === "cockpit"
+                ? flightCameraCockpitOffsetRef.current
+                : flightCameraBoresightOffsetRef.current;
+            dockingCameraPresentationOffsetRef.current
+                .copy(baseFlightCameraOffset)
+                .lerp(dockingCameraDockingOffsetRef.current, dockingCameraPresentationBlend);
+            if (activeApproachStage === "hold-align") {
+                const dynamicHoldDistance = clamp(
+                    (distanceToPort * 0.22) + 0.18,
+                    0.28,
+                    0.62,
+                );
+                dockingApproachHoldPointRef.current
+                    .copy(portPosition)
+                    .addScaledVector(entryVector, dynamicHoldDistance);
+            }
+            const stageTarget = activeApproachStage === "final-approach"
+                ? portCorePosition
+                : activeApproachStage === "tunnel-entry"
+                    ? tunnelEntryPosition
+                    : dockingApproachHoldPointRef.current;
+            const stageDistanceRemaining = ship.position.distanceTo(stageTarget);
+            const rotationMatchInRange = (
+                Boolean(dockingRotationMatchEnabled)
+                && activeApproachStage !== "hold-entry"
+                &&
+                distanceToPort <= DOCKING_PORT_ROTATION_MATCH_RANGE_KM
+            );
 
             const pathDirection = dockingDesiredVectorRef.current
                 .copy(stageTarget)
@@ -1507,11 +2455,9 @@ function FlightSceneContent({
             const avoidanceVector = dockingAvoidanceVectorRef.current.set(0, 0, 0);
             for (const trafficContact of shipContacts) {
                 dockingTemporaryVectorRef.current
-                    .set(
-                        ship.position.x - trafficContact.scene_x,
-                        ship.position.y - trafficContact.scene_y,
-                        ship.position.z - trafficContact.scene_z,
-                    );
+                    .copy(resolveContactRenderPosition(trafficContact, dockingTemporaryVectorRef.current))
+                    .sub(ship.position)
+                    .multiplyScalar(-1);
                 const trafficDistance = dockingTemporaryVectorRef.current.length();
                 if (trafficDistance <= 0.001 || trafficDistance >= DOCKING_AVOIDANCE_RADIUS) {
                     continue;
@@ -1535,21 +2481,96 @@ function FlightSceneContent({
                 activeApproachStage === "final-approach"
                 && distanceToPort <= DOCKING_FINAL_CAPTURE_DISTANCE_KM
             );
-            const orientation = dockingOrientationQuaternionRef.current.setFromEuler(
+            dockingCameraTargetFovRef.current = activeApproachStage === "final-approach"
+                ? (
+                    finalCaptureActive
+                        ? DOCKING_CAMERA_CAPTURE_FOV
+                        : (
+                            DOCKING_CAMERA_FINAL_FOV
+                            + ((FLIGHT_CAMERA_BASE_FOV - DOCKING_CAMERA_FINAL_FOV)
+                                * (1 - dockingCameraPresentationBlend))
+                        )
+                )
+                    : activeApproachStage === "hold-align"
+                        ? (
+                            FLIGHT_CAMERA_BASE_FOV
+                            - ((FLIGHT_CAMERA_BASE_FOV - DOCKING_CAMERA_HOLD_ALIGN_FOV)
+                                * dockingCameraPresentationBlend)
+                        )
+                    : FLIGHT_CAMERA_BASE_FOV;
+            dockingCameraTargetNearRef.current = activeApproachStage === "final-approach"
+                ? (
+                    finalCaptureActive
+                        ? DOCKING_CAMERA_CAPTURE_NEAR
+                        : (
+                            DOCKING_CAMERA_FINAL_NEAR
+                            + ((FLIGHT_CAMERA_BASE_NEAR - DOCKING_CAMERA_FINAL_NEAR)
+                                * (1 - dockingCameraPresentationBlend))
+                        )
+                )
+                : activeApproachStage === "hold-align"
+                    ? (
+                        FLIGHT_CAMERA_BASE_NEAR
+                        - ((FLIGHT_CAMERA_BASE_NEAR - DOCKING_CAMERA_HOLD_ALIGN_NEAR)
+                            * dockingCameraPresentationBlend)
+                    )
+                    : FLIGHT_CAMERA_BASE_NEAR;
+            const cameraOffsetOrientation = dockingCameraOffsetQuaternionRef.current.setFromEuler(
                 dockingOrientationEulerRef.current.set(
                     pitchRef.current,
                     yawRef.current,
-                    rollRef.current,
+                    0,
                     "YXZ",
                 ),
             );
             const cameraAimPosition = dockingCameraAimPositionRef.current
-                .copy(cockpitOffsetRef.current)
-                .applyQuaternion(orientation)
+                .copy(dockingCameraPresentationOffsetRef.current)
+                .applyQuaternion(cameraOffsetOrientation)
                 .add(ship.position);
             const cameraToPort = dockingCameraToPortRef.current
                 .copy(portCorePosition)
                 .sub(cameraAimPosition);
+            const sceneCamera = state.camera as PerspectiveCamera;
+            const displayedDockingCameraFov = sceneCamera.fov + (
+                dockingCameraTargetFovRef.current - sceneCamera.fov
+            ) * clamp(DOCKING_CAMERA_FOV_SMOOTH_RATE * delta, 0, 1);
+            const portCameraSpace = dockingPortCameraSpaceRef.current
+                .copy(portCorePosition)
+                .sub(cameraAimPosition)
+                .applyQuaternion(
+                    dockingCameraInverseQuaternionRef.current
+                        .copy(
+                            dockingCameraQuaternionRef.current.setFromEuler(
+                                dockingOrientationEulerRef.current.set(
+                                    pitchRef.current,
+                                    yawRef.current,
+                                    rollRef.current,
+                                    "YXZ",
+                                ),
+                            ),
+                        )
+                        .invert(),
+                );
+            const portScreenProjection = projectCameraSpacePointToNdc({
+                cameraSpaceX: portCameraSpace.x,
+                cameraSpaceY: portCameraSpace.y,
+                cameraSpaceZ: portCameraSpace.z,
+                verticalFovDegrees: displayedDockingCameraFov,
+                aspectRatio: Math.max(0.1, sceneCamera.aspect),
+            });
+            const screenValidity = calculateDockingScreenValidity({
+                ndcX: portScreenProjection.ndcX,
+                ndcY: portScreenProjection.ndcY,
+                inView: portScreenProjection.inView,
+                centerMaxX: DOCKING_COMPLETE_SCREEN_CENTER_MAX_X,
+                centerMaxY: DOCKING_COMPLETE_SCREEN_CENTER_MAX_Y,
+                strictCenterMaxX: DOCKING_COMPLETE_SCREEN_STRICT_CENTER_MAX_X,
+                strictCenterMaxY: DOCKING_COMPLETE_SCREEN_STRICT_CENTER_MAX_Y,
+            });
+            const {
+                portVisibleOnScreen,
+                portCenteredOnScreen,
+            } = screenValidity;
             if (cameraToPort.lengthSq() > 0.000001) {
                 cameraToPort.normalize();
                 const reticleBlend = activeApproachStage === "hold-entry"
@@ -1575,8 +2596,16 @@ function FlightSceneContent({
                             );
                 if (activeApproachStage === "hold-entry") {
                     aimDirection.lerp(cameraToPort, reticleBlend).normalize();
+                } else if (finalCaptureActive) {
+                    aimDirection.copy(pathDirection).normalize();
                 } else {
-                    aimDirection.copy(cameraToPort);
+                    const cameraBias = finalCaptureActive
+                        ? DOCKING_RETICLE_CAMERA_BIAS_CAPTURE
+                        : activeApproachStage === "hold-align"
+                            ? DOCKING_RETICLE_CAMERA_BIAS_HOLD_ALIGN
+                            : DOCKING_RETICLE_CAMERA_BIAS_FINAL;
+                    aimDirection.copy(pathDirection);
+                    aimDirection.lerp(cameraToPort, cameraBias).normalize();
                 }
             }
             const filteredAimDirection = dockingFilteredAimDirectionRef.current;
@@ -1647,10 +2676,6 @@ function FlightSceneContent({
             yawRef.current = nextAttitude.yawRadians;
             pitchRef.current = nextAttitude.pitchRadians;
 
-            rollRef.current = normalizeSignedAngle(
-                rollRef.current * Math.max(0, 1 - ((finalCaptureActive ? 5.2 : 3.2) * delta)),
-            );
-
             const shipToPortDirection = dockingShipToPortDirectionRef.current
                 .copy(portCorePosition)
                 .sub(ship.position);
@@ -1668,7 +2693,22 @@ function FlightSceneContent({
                     "YXZ",
                 ))
                 .normalize();
-            const reticleAlignmentCosine = shipForward.dot(shipToPortDirection);
+            const reticleAlignmentDirection = dockingAlignmentDirectionRef.current
+                .copy(shipToPortDirection);
+            if (cameraToPort.lengthSq() > 0.000001) {
+                const closeRangeAlignmentBlend = clamp(
+                    1 - (distanceToPort / DOCKING_RETICLE_ALIGNMENT_BLEND_RANGE_KM),
+                    0,
+                    1,
+                );
+                reticleAlignmentDirection.lerp(cameraToPort, closeRangeAlignmentBlend);
+                if (reticleAlignmentDirection.lengthSq() <= 0.000001) {
+                    reticleAlignmentDirection.copy(shipToPortDirection);
+                } else {
+                    reticleAlignmentDirection.normalize();
+                }
+            }
+            const reticleAlignmentCosine = shipForward.dot(reticleAlignmentDirection);
             const corridorLateralOffset = (() => {
                 const offsetFromPort = dockingTemporaryVectorRef.current
                     .copy(ship.position)
@@ -1677,10 +2717,71 @@ function FlightSceneContent({
                 offsetFromPort.addScaledVector(entryVector, -projectedAlongEntry);
                 return offsetFromPort.length();
             })();
+            const holdEntryTransition = activeApproachStage === "hold-entry"
+                ? resolveDockingStageTransition({
+                    stage: activeApproachStage,
+                    nowMs: performance.now(),
+                    stageStartedAtMs: dockingApproachStageStartedAtRef.current,
+                    holdAlignAlignedSinceMs: dockingHoldAlignAlignedSinceRef.current,
+                    lastResetAtMs: dockingLastResetAtRef.current,
+                    lastFinalReacquireAtMs: dockingFinalReacquireLastAtRef.current,
+                    holdEntryDistanceRemainingKm: holdEntryDistanceRemaining,
+                    distanceToPortKm: distanceToPort,
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    stageDistanceRemainingKm: stageDistanceRemaining,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                    tunnelPenetrationDepthKm,
+                    config: dockingStageTransitionConfig,
+                })
+                : null;
+            if (holdEntryTransition) {
+                dockingApproachStageRef.current = holdEntryTransition.nextStage;
+                dockingApproachStageStartedAtRef.current = performance.now();
+                dockingHoldAlignAlignedSinceRef.current = 0;
+                onDockingDebug?.({
+                    event: "stage-transition",
+                    jumpPhase,
+                    contactId: approachTargetId,
+                    targetName: dockingApproachTargetContact.name,
+                    stage: holdEntryTransition.nextStage,
+                    reason: holdEntryTransition.reason,
+                    distanceToPortKm: distanceToPort,
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                });
+            }
+            const applyRotationMatch = resolveDockingRotationMatch({
+                stage: activeApproachStage,
+                rotationMatchEnabled: rotationMatchInRange,
+                rotationMatchLatched: dockingRotationMatchLatchedRef.current,
+                distanceToPortKm: distanceToPort,
+                reticleAlignmentCosine,
+                corridorLateralOffsetKm: corridorLateralOffset,
+                config: dockingRotationMatchConfig,
+            });
+            dockingRotationMatchLatchedRef.current = applyRotationMatch;
+
+            if (applyRotationMatch) {
+                const desiredRoll = normalizeSignedAngle(
+                    resolveStationRotationRadians(
+                        dockingApproachTargetContact,
+                        state.clock.elapsedTime,
+                    ),
+                );
+                const rollDelta = normalizeSignedAngle(desiredRoll - rollRef.current);
+                const maxRollStep = DOCKING_ROTATION_MATCH_ROLL_RATE * delta;
+                const nextRollStep = clamp(rollDelta, -maxRollStep, maxRollStep);
+                rollRef.current = normalizeSignedAngle(rollRef.current + nextRollStep);
+            } else {
+                rollRef.current = normalizeSignedAngle(
+                    rollRef.current * Math.max(0, 1 - ((finalCaptureActive ? 5.2 : 3.2) * delta)),
+                );
+            }
 
             if (activeApproachStage === "hold-align") {
                 const nowMs = performance.now();
-                const holdAlignElapsedMs = nowMs - dockingApproachStageStartedAtRef.current;
                 const holdAlignAligned = (
                     reticleAlignmentCosine >= DOCKING_HOLD_ALIGN_REQUIRED_COSINE
                     && stageDistanceRemaining <= DOCKING_HOLD_POINT_THRESHOLD
@@ -1693,24 +2794,180 @@ function FlightSceneContent({
                 } else {
                     dockingHoldAlignAlignedSinceRef.current = 0;
                 }
-                const holdAlignStableMs = dockingHoldAlignAlignedSinceRef.current > 0
-                    ? nowMs - dockingHoldAlignAlignedSinceRef.current
-                    : 0;
-                const holdAlignTimeout = holdAlignElapsedMs >= DOCKING_HOLD_ALIGN_MAX_DURATION_MS;
-                const holdAlignTimeoutEligible = (
-                    reticleAlignmentCosine >= DOCKING_HOLD_ALIGN_TIMEOUT_REQUIRED_COSINE
-                    && corridorLateralOffset <= DOCKING_HOLD_ALIGN_TIMEOUT_CORRIDOR_TOLERANCE_KM
-                );
-                if (
-                    (holdAlignTimeout && holdAlignTimeoutEligible)
-                    || (
-                        holdAlignElapsedMs >= DOCKING_HOLD_ALIGN_DURATION_MS
-                        && holdAlignStableMs >= DOCKING_HOLD_ALIGN_STABLE_MS
-                    )
-                ) {
-                    dockingApproachStageRef.current = "final-approach";
+                const holdAlignTransition = resolveDockingStageTransition({
+                    stage: activeApproachStage,
+                    nowMs,
+                    stageStartedAtMs: dockingApproachStageStartedAtRef.current,
+                    holdAlignAlignedSinceMs: dockingHoldAlignAlignedSinceRef.current,
+                    lastResetAtMs: dockingLastResetAtRef.current,
+                    lastFinalReacquireAtMs: dockingFinalReacquireLastAtRef.current,
+                    holdEntryDistanceRemainingKm: holdEntryDistanceRemaining,
+                    distanceToPortKm: distanceToPort,
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    stageDistanceRemainingKm: stageDistanceRemaining,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                    tunnelPenetrationDepthKm,
+                    config: dockingStageTransitionConfig,
+                });
+                if (holdAlignTransition) {
+                    if (holdAlignTransition.nextStage === "hold-entry") {
+                        dockingLastResetAtRef.current = nowMs;
+                        const resetHoldDistance = DOCKING_RESET_HOLD_DISTANCE_MIN
+                            + (Math.random()
+                                * (DOCKING_RESET_HOLD_DISTANCE_MAX - DOCKING_RESET_HOLD_DISTANCE_MIN));
+                        dockingApproachHoldPointRef.current
+                            .copy(portPosition)
+                            .addScaledVector(entryVector, resetHoldDistance);
+                        worldVelocityRef.current.multiplyScalar(0.4);
+                    }
+                    dockingApproachStageRef.current = holdAlignTransition.nextStage;
                     dockingApproachStageStartedAtRef.current = nowMs;
                     dockingHoldAlignAlignedSinceRef.current = 0;
+                    onDockingDebug?.({
+                        event: "stage-transition",
+                        jumpPhase,
+                        contactId: approachTargetId,
+                        targetName: dockingApproachTargetContact.name,
+                        stage: holdAlignTransition.nextStage,
+                        reason: holdAlignTransition.reason,
+                        distanceToPortKm: distanceToPort,
+                        distanceToApproachPointKm: distanceToApproachPoint,
+                        reticleAlignmentCosine,
+                        corridorLateralOffsetKm: corridorLateralOffset,
+                    });
+                }
+            }
+
+            if (activeApproachStage === "tunnel-entry") {
+                const nowMs = performance.now();
+                const tunnelEntryTransition = resolveDockingStageTransition({
+                    stage: activeApproachStage,
+                    nowMs,
+                    stageStartedAtMs: dockingApproachStageStartedAtRef.current,
+                    holdAlignAlignedSinceMs: dockingHoldAlignAlignedSinceRef.current,
+                    lastResetAtMs: dockingLastResetAtRef.current,
+                    lastFinalReacquireAtMs: dockingFinalReacquireLastAtRef.current,
+                    holdEntryDistanceRemainingKm: holdEntryDistanceRemaining,
+                    distanceToPortKm: distanceToPort,
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    stageDistanceRemainingKm: stageDistanceRemaining,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                    tunnelPenetrationDepthKm,
+                    config: dockingStageTransitionConfig,
+                });
+                if (tunnelEntryTransition) {
+                    dockingApproachStageRef.current = tunnelEntryTransition.nextStage;
+                    dockingApproachStageStartedAtRef.current = nowMs;
+                    onDockingDebug?.({
+                        event: "stage-transition",
+                        jumpPhase,
+                        contactId: approachTargetId,
+                        targetName: dockingApproachTargetContact.name,
+                        stage: tunnelEntryTransition.nextStage,
+                        reason: tunnelEntryTransition.reason,
+                        distanceToPortKm: distanceToPort,
+                        distanceToApproachPointKm: distanceToApproachPoint,
+                        reticleAlignmentCosine,
+                        corridorLateralOffsetKm: corridorLateralOffset,
+                    });
+                }
+            }
+
+            if (activeApproachStage === "final-approach") {
+                const nowMs = performance.now();
+                const finalApproachTransition = resolveDockingStageTransition({
+                    stage: activeApproachStage,
+                    nowMs,
+                    stageStartedAtMs: dockingApproachStageStartedAtRef.current,
+                    holdAlignAlignedSinceMs: dockingHoldAlignAlignedSinceRef.current,
+                    lastResetAtMs: dockingLastResetAtRef.current,
+                    lastFinalReacquireAtMs: dockingFinalReacquireLastAtRef.current,
+                    holdEntryDistanceRemainingKm: holdEntryDistanceRemaining,
+                    distanceToPortKm: distanceToPort,
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    stageDistanceRemainingKm: stageDistanceRemaining,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                    tunnelPenetrationDepthKm,
+                    config: dockingStageTransitionConfig,
+                });
+                if (finalApproachTransition) {
+                    dockingFinalReacquireLastAtRef.current = nowMs;
+                    const reacquireHoldDistance = clamp(
+                        distanceToPort + 0.32,
+                        0.48,
+                        1.05,
+                    );
+                    dockingApproachHoldPointRef.current
+                        .copy(portPosition)
+                        .addScaledVector(entryVector, reacquireHoldDistance);
+                    dockingApproachStageRef.current = finalApproachTransition.nextStage;
+                    dockingApproachStageStartedAtRef.current = nowMs;
+                    dockingHoldAlignAlignedSinceRef.current = 0;
+                    onDockingDebug?.({
+                        event: "stage-transition",
+                        jumpPhase,
+                        contactId: approachTargetId,
+                        targetName: dockingApproachTargetContact.name,
+                        stage: finalApproachTransition.nextStage,
+                        reason: finalApproachTransition.reason,
+                        distanceToPortKm: distanceToPort,
+                        distanceToApproachPointKm: distanceToApproachPoint,
+                        reticleAlignmentCosine,
+                        corridorLateralOffsetKm: corridorLateralOffset,
+                    });
+                }
+            }
+
+            if (onDockingDebug) {
+                const nowMs = performance.now();
+                if (nowMs - lastDockingDebugTelemetryAtRef.current >= 250) {
+                    lastDockingDebugTelemetryAtRef.current = nowMs;
+                    onDockingDebug({
+                        event: "telemetry",
+                        jumpPhase,
+                        contactId: approachTargetId,
+                        targetName: dockingApproachTargetContact.name,
+                        stage: activeApproachStage,
+                        distanceToPortKm: distanceToPort,
+                        distanceToApproachPointKm: distanceToApproachPoint,
+                        stageDistanceRemainingKm: stageDistanceRemaining,
+                        reticleAlignmentCosine,
+                        corridorLateralOffsetKm: corridorLateralOffset,
+                        shouldMatchStationRotation: applyRotationMatch,
+                        stationRotationRadians: resolveStationRotationRadians(
+                            dockingApproachTargetContact,
+                            state.clock.elapsedTime,
+                        ),
+                        shipSpeedKmPerSec: worldVelocityRef.current.length(),
+                        shipPosition: {
+                            x: ship.position.x,
+                            y: ship.position.y,
+                            z: ship.position.z,
+                        },
+                        stationCenter: {
+                            x: stationCenter.x,
+                            y: stationCenter.y,
+                            z: stationCenter.z,
+                        },
+                        portCorePosition: {
+                            x: portCorePosition.x,
+                            y: portCorePosition.y,
+                            z: portCorePosition.z,
+                        },
+                        portApproachPosition: {
+                            x: portPosition.x,
+                            y: portPosition.y,
+                            z: portPosition.z,
+                        },
+                        portVisibleOnScreen,
+                        portCenteredOnScreen,
+                        portScreenOffsetX: portScreenProjection.ndcX,
+                        portScreenOffsetY: portScreenProjection.ndcY,
+                        portScreenDepthKm: portScreenProjection.depth,
+                    });
                 }
             }
 
@@ -1725,6 +2982,12 @@ function FlightSceneContent({
                         Math.max(0.04, stageDistanceRemaining * 0.22),
                         0.04,
                         DOCKING_HOLD_ALIGN_MAX_SPEED,
+                    )
+                : activeApproachStage === "tunnel-entry"
+                    ? clamp(
+                        Math.max(DOCKING_TUNNEL_ENTRY_MIN_SPEED, stageDistanceRemaining * 0.34),
+                        DOCKING_TUNNEL_ENTRY_MIN_SPEED,
+                        DOCKING_TUNNEL_ENTRY_MAX_SPEED,
                     )
                 : (() => {
                     const finalMinSpeed = finalCaptureActive
@@ -1741,6 +3004,32 @@ function FlightSceneContent({
                         finalMaxSpeed,
                     );
                 })();
+            if (
+                activeApproachStage === "hold-entry"
+                && distanceToPort <= DOCKING_HOLD_ENTRY_NEAR_PORT_DISTANCE_KM
+            ) {
+                desiredSpeed = Math.min(desiredSpeed, DOCKING_HOLD_ENTRY_NEAR_PORT_SPEED);
+            }
+            const holdAlignNeedsRecovery = (
+                activeApproachStage === "hold-align"
+                && (
+                    reticleAlignmentCosine <= DOCKING_HOLD_ALIGN_RESET_ALIGNMENT_COSINE
+                    || corridorLateralOffset >= DOCKING_HOLD_ALIGN_RESET_CORRIDOR_MIN_KM
+                )
+            );
+            if (holdAlignNeedsRecovery) {
+                desiredSpeed = Math.min(desiredSpeed, DOCKING_HOLD_ALIGN_RECOVERY_MAX_SPEED);
+            }
+            const finalApproachNeedsRecovery = (
+                activeApproachStage === "final-approach"
+                && (
+                    reticleAlignmentCosine < DOCKING_FINAL_RECOVERY_ALIGNMENT_COSINE
+                    || corridorLateralOffset > DOCKING_FINAL_RECOVERY_CORRIDOR_MAX_KM
+                )
+            );
+            if (finalApproachNeedsRecovery) {
+                desiredSpeed = Math.min(desiredSpeed, DOCKING_FINAL_RECOVERY_MAX_SPEED);
+            }
             if (closeRangeFinalApproach && !finalCaptureActive) {
                 const closeRangeBrakeCap = Math.max(
                     DOCKING_FINAL_CLOSE_MIN_SPEED,
@@ -1757,12 +3046,26 @@ function FlightSceneContent({
                 );
             }
             const driveDirection = dockingVelocityTargetDirectionRef.current.copy(pathDirection);
-            if (activeApproachStage !== "hold-entry") {
-                const trajectoryAimBlend = finalCaptureActive
-                    ? DOCKING_TRAJECTORY_AIM_BLEND_CAPTURE
-                    : activeApproachStage === "final-approach"
-                        ? DOCKING_TRAJECTORY_AIM_BLEND_FINAL
-                        : DOCKING_TRAJECTORY_AIM_BLEND_HOLD_ALIGN;
+            const baseTrajectoryAimBlend = finalCaptureActive
+                ? DOCKING_TRAJECTORY_AIM_BLEND_CAPTURE
+                : activeApproachStage === "final-approach"
+                    ? DOCKING_TRAJECTORY_AIM_BLEND_FINAL
+                    : activeApproachStage === "hold-align"
+                        ? DOCKING_TRAJECTORY_AIM_BLEND_HOLD_ALIGN
+                        : DOCKING_TRAJECTORY_AIM_BLEND_HOLD_ENTRY;
+            const trajectoryAimBlend = activeApproachStage === "final-approach" && !finalCaptureActive
+                ? Math.max(
+                    0.12,
+                    baseTrajectoryAimBlend * (
+                        1 - (clamp(
+                            corridorLateralOffset / DOCKING_FINAL_RECOVERY_CORRIDOR_MAX_KM,
+                            0,
+                            1,
+                        ) * 0.75)
+                    ),
+                )
+                : baseTrajectoryAimBlend;
+            if (trajectoryAimBlend > 0) {
                 driveDirection.lerp(filteredAimDirection, trajectoryAimBlend);
                 if (driveDirection.lengthSq() <= 0.000001) {
                     driveDirection.copy(pathDirection);
@@ -1778,6 +3081,15 @@ function FlightSceneContent({
                 .sub(worldVelocityRef.current);
             const speedDelta = desiredSpeed - worldVelocityRef.current.length();
             let acceleration = speedDelta >= 0 ? FORWARD_ACCELERATION : REVERSE_ACCELERATION;
+            if (activeApproachStage === "hold-entry") {
+                acceleration = Math.min(acceleration, DOCKING_HOLD_ENTRY_ACCELERATION);
+            } else if (activeApproachStage === "hold-align") {
+                acceleration = Math.min(acceleration, DOCKING_HOLD_ALIGN_ACCELERATION);
+            } else if (activeApproachStage === "tunnel-entry") {
+                acceleration = Math.min(acceleration, DOCKING_TUNNEL_ENTRY_ACCELERATION);
+            } else if (activeApproachStage === "final-approach") {
+                acceleration = Math.min(acceleration, DOCKING_FINAL_APPROACH_ACCELERATION);
+            }
             if (finalCaptureActive) {
                 acceleration = Math.min(acceleration, DOCKING_FINAL_CAPTURE_ACCELERATION);
             } else if (closeRangeFinalApproach) {
@@ -1814,34 +3126,69 @@ function FlightSceneContent({
                 && activeApproachStage === "final-approach"
             ) {
                 const finalApproachElapsedMs = performance.now() - dockingApproachStageStartedAtRef.current;
-                const reticleAligned = reticleAlignmentCosine >= DOCKING_FINAL_CAPTURE_ALIGNMENT_COSINE;
+                const completionWindow = resolveDockingCompletionWindow({
+                    finalApproachElapsedMs,
+                    distanceToPortKm: distanceToPort,
+                    tunnelPenetrationDepthKm: tunnelPenetrationDepthKm,
+                    reticleAlignmentCosine,
+                    corridorLateralOffsetKm: corridorLateralOffset,
+                    shipSpeedKmPerSec: worldVelocityRef.current.length(),
+                    distanceToApproachPointKm: distanceToApproachPoint,
+                    screenValidity,
+                    config: dockingCompletionConfig,
+                });
 
-                if (finalApproachElapsedMs >= DOCKING_FINAL_STAGE_MIN_DURATION_MS) {
-                    const directPortWindowReached = (
-                        distanceToPort <= DOCKING_PORT_THRESHOLD
-                        && reticleAligned
-                    );
-                    const fallbackWindowReached = (
-                        finalApproachElapsedMs >= DOCKING_FINAL_STAGE_FORCE_COMPLETE_MS
-                        && distanceToPort <= DOCKING_PORT_FALLBACK_THRESHOLD
-                        && distanceToApproachPoint <= DOCKING_PORT_THRESHOLD
-                    );
-
-                    if (directPortWindowReached || fallbackWindowReached) {
-                        velocityRef.current = 0;
-                        worldVelocityRef.current.set(0, 0, 0);
-                        dockingApproachCompleteSentRef.current = true;
-                        if (onDockingApproachProgress) {
-                            onDockingApproachProgress({
-                                progress: 100,
-                                distanceKm: 0,
-                                targetName: dockingApproachTargetContact.name,
-                                stage: "final-approach",
-                            });
-                        }
-                        onDockingApproachComplete?.();
-                        return;
+                if (completionWindow.completed) {
+                    onDockingDebug?.({
+                        event: "complete-window",
+                        jumpPhase,
+                        contactId: approachTargetId,
+                        targetName: dockingApproachTargetContact.name,
+                        stage: "final-approach",
+                        reason: completionWindow.reason ?? undefined,
+                        distanceToPortKm: distanceToPort,
+                        distanceToApproachPointKm: distanceToApproachPoint,
+                        reticleAlignmentCosine,
+                        corridorLateralOffsetKm: corridorLateralOffset,
+                        shipPosition: {
+                            x: ship.position.x,
+                            y: ship.position.y,
+                            z: ship.position.z,
+                        },
+                        stationCenter: {
+                            x: stationCenter.x,
+                            y: stationCenter.y,
+                            z: stationCenter.z,
+                        },
+                        portCorePosition: {
+                            x: portCorePosition.x,
+                            y: portCorePosition.y,
+                            z: portCorePosition.z,
+                        },
+                        portApproachPosition: {
+                            x: portPosition.x,
+                            y: portPosition.y,
+                            z: portPosition.z,
+                        },
+                        portVisibleOnScreen,
+                        portCenteredOnScreen,
+                        portScreenOffsetX: portScreenProjection.ndcX,
+                        portScreenOffsetY: portScreenProjection.ndcY,
+                        portScreenDepthKm: portScreenProjection.depth,
+                    });
+                    velocityRef.current = 0;
+                    worldVelocityRef.current.set(0, 0, 0);
+                    dockingApproachCompleteSentRef.current = true;
+                    if (onDockingApproachProgress) {
+                        onDockingApproachProgress({
+                            progress: 100,
+                            distanceKm: 0,
+                            targetName: dockingApproachTargetContact.name,
+                            stage: "final-approach",
+                        });
                     }
+                    onDockingApproachComplete?.();
+                    return;
                 }
             }
 
@@ -1953,41 +3300,30 @@ function FlightSceneContent({
         ship.position.z += worldVelocityRef.current.z * delta;
 
         const isDockingSequenceActive = (
-            isDockingApproachActive
+            dockingApproachRequested
             || jumpPhase === "docking-approach"
             || jumpPhase === "docking-transit-internal"
         );
         if (onCollision && !isDockingSequenceActive) {
-            const collisionRadiusByType: Record<Exclude<
-                ScannerAnchorContact["contact_type"],
-                "station"
-            >, number> = {
-                ship: 0.72,
-                planet: 2.0,
-                moon: 1.55,
-                star: 2.4,
-            };
             let nearestCollision: {
                 contact: ScannerAnchorContact;
                 distance: number;
             } | null = null;
 
             for (const contact of scannerContacts) {
+                if (
+                    contact.contact_type !== "station"
+                    && contact.contact_type !== "ship"
+                ) {
+                    continue;
+                }
                 const radius = contact.contact_type === "station"
-                    ? (() => {
-                        const shape = resolveStationShapeKey(contact.station_archetype_shape);
-                        const baseStationRadius = shape === "orbis" ? 4.9 : 5.9;
-                        const stationRadius = (
-                            baseStationRadius * stationDistanceScale(contact.distance_km)
-                        ) + 0.08;
-                        return Math.max(0.22, stationRadius);
-                    })()
-                    : collisionRadiusByType[contact.contact_type];
-                const distance = Math.hypot(
-                    contact.scene_x - ship.position.x,
-                    contact.scene_y - ship.position.y,
-                    contact.scene_z - ship.position.z,
-                );
+                    ? resolveStationCollisionRadiusKm(contact)
+                    : 0.72;
+                const distance = resolveContactRenderPosition(
+                    contact,
+                    dockingTemporaryVectorRef.current,
+                ).distanceTo(ship.position);
                 if (distance > radius) {
                     continue;
                 }
@@ -2007,7 +3343,6 @@ function FlightSceneContent({
                     const speed = worldVelocityRef.current.length();
                     const severity: "glancing" | "critical" = (
                         nearestCollision.contact.contact_type === "station"
-                        || nearestCollision.contact.contact_type === "star"
                         || speed >= 3.5
                     )
                         ? "critical"
@@ -2028,15 +3363,52 @@ function FlightSceneContent({
         }
 
         const camera = state.camera as PerspectiveCamera;
+        const cameraBlendTarget = isDockingSequenceActive
+            ? dockingCameraPresentationTargetRef.current
+            : 0;
+        const cameraBlendStep = clamp(DOCKING_CAMERA_BLEND_SMOOTH_RATE * delta, 0, 1);
+        dockingCameraPresentationBlendRef.current += (
+            cameraBlendTarget - dockingCameraPresentationBlendRef.current
+        ) * cameraBlendStep;
+        const cameraPresentationBlend = dockingCameraPresentationBlendRef.current;
+        const cameraOffsetOrientation = isDockingSequenceActive
+            ? dockingCameraOffsetQuaternionRef.current.setFromEuler(
+                dockingOrientationEulerRef.current.set(
+                    pitchRef.current,
+                    yawRef.current,
+                    0,
+                    "YXZ",
+                ),
+            )
+            : ship.quaternion;
+        const baseFlightCameraOffset = cameraMode === "cockpit"
+            ? flightCameraCockpitOffsetRef.current
+            : flightCameraBoresightOffsetRef.current;
+        const cameraOffsetTarget = cameraOffsetTargetRef.current
+            .copy(baseFlightCameraOffset)
+            .lerp(dockingCameraDockingOffsetRef.current, cameraPresentationBlend);
+        const blendedCameraOffset = cameraOffsetBlendRef.current.lerp(
+            cameraOffsetTarget,
+            cameraBlendStep,
+        );
         const cockpitOffset = cockpitWorldOffsetRef.current
-            .copy(cockpitOffsetRef.current)
-            .applyQuaternion(ship.quaternion);
+            .copy(blendedCameraOffset)
+            .applyQuaternion(cameraOffsetOrientation);
         camera.position.set(
             ship.position.x + cockpitOffset.x,
             ship.position.y + cockpitOffset.y,
             ship.position.z + cockpitOffset.z,
         );
         camera.quaternion.copy(ship.quaternion);
+        const targetFov = isDockingSequenceActive
+            ? dockingCameraTargetFovRef.current
+            : FLIGHT_CAMERA_BASE_FOV;
+        const fovStep = clamp(DOCKING_CAMERA_FOV_SMOOTH_RATE * delta, 0, 1);
+        camera.fov += (targetFov - camera.fov) * fovStep;
+        camera.near = isDockingSequenceActive
+            ? dockingCameraTargetNearRef.current
+            : FLIGHT_CAMERA_BASE_NEAR;
+        camera.updateProjectionMatrix();
 
         const inverseCameraOrientation = scannerInverseQuaternionRef.current
             .copy(camera.quaternion)
@@ -2052,12 +3424,17 @@ function FlightSceneContent({
                 return;
             }
 
+            stationGroup.rotation.set(
+                0,
+                0,
+                resolveStationRotationRadians(contact, state.clock.elapsedTime),
+            );
+            const baseStationScale = resolveStationRenderScale(contact);
+            stationGroup.scale.set(baseStationScale, baseStationScale, baseStationScale);
+
             const relativeFromCamera = scannerCameraRelativeVectorRef.current
-                .set(
-                    contact.scene_x - camera.position.x,
-                    contact.scene_y - camera.position.y,
-                    contact.scene_z - camera.position.z,
-                )
+                .copy(resolveContactRenderPosition(contact, scannerCameraRelativeVectorRef.current))
+                .sub(camera.position)
                 .applyQuaternion(inverseCameraOrientation);
 
             const cameraForwardDistance = -relativeFromCamera.z;
@@ -2073,7 +3450,7 @@ function FlightSceneContent({
                 ? (relativeFromCamera.y / cameraForwardDistance) / tanVerticalHalfFov
                 : Number.POSITIVE_INFINITY;
 
-            const stationScale = stationDistanceScale(contact.distance_km);
+            const stationScale = resolveStationRenderScale(contact);
             const stationRadius = 5.9 * stationScale;
             const distanceToContact = Math.max(0.001, relativeFromCamera.length());
             const apparentRadius = stationRadius / distanceToContact;
@@ -2110,11 +3487,8 @@ function FlightSceneContent({
 
                 const telemetryContacts = scannerContacts.map((contact) => {
                     const relativeFromShip = scannerRelativeVectorRef.current
-                        .set(
-                            contact.scene_x - ship.position.x,
-                            contact.scene_y - ship.position.y,
-                            contact.scene_z - ship.position.z,
-                        )
+                        .copy(resolveContactRenderPosition(contact, scannerRelativeVectorRef.current))
+                        .sub(ship.position)
                         .applyQuaternion(inverseOrientation);
 
                     const relativeX = relativeFromShip.x;
@@ -2125,7 +3499,7 @@ function FlightSceneContent({
                         ? Math.max(0, centerDistance - resolveStationCollisionRadiusKm(contact))
                         : centerDistance;
                     const isDockingPortDistanceContact = (
-                        isDockingApproachActive
+                        dockingApproachRequested
                         && contact.contact_type === "station"
                         && contact.id === dockingApproachContactId
                     );
@@ -2139,6 +3513,7 @@ function FlightSceneContent({
                         const portWorldPosition = resolveDockingPortWorldPosition(
                             contact,
                             dockingCameraToPortRef.current,
+                            state.clock.elapsedTime,
                         );
                         return Math.hypot(
                             portWorldPosition.x - ship.position.x,
@@ -2152,11 +3527,8 @@ function FlightSceneContent({
                     const altitude = clamp(relativeY / SCANNER_ALTITUDE_RANGE, -1, 1);
 
                     const relativeFromCamera = scannerCameraRelativeVectorRef.current
-                        .set(
-                            contact.scene_x - camera.position.x,
-                            contact.scene_y - camera.position.y,
-                            contact.scene_z - camera.position.z,
-                        )
+                        .copy(resolveContactRenderPosition(contact, scannerCameraRelativeVectorRef.current))
+                        .sub(camera.position)
                         .applyQuaternion(inverseOrientation);
 
                     const cameraForwardDistance = -relativeFromCamera.z;
@@ -2195,6 +3567,21 @@ function FlightSceneContent({
                         relative_x: relativeX,
                         relative_y: relativeY,
                         relative_z: relativeZ,
+                        relative_x_km: (
+                            contactUsesPhysicalNearFieldSpace(contact)
+                        )
+                            ? relativeX / LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM
+                            : undefined,
+                        relative_y_km: (
+                            contactUsesPhysicalNearFieldSpace(contact)
+                        )
+                            ? relativeY / LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM
+                            : undefined,
+                        relative_z_km: (
+                            contactUsesPhysicalNearFieldSpace(contact)
+                        )
+                            ? relativeZ / LOCAL_NEAR_FIELD_RENDER_UNITS_PER_KM
+                            : undefined,
                         forward_distance: forwardDistance,
                         plane_x: planarX,
                         plane_y: planarY,
@@ -2288,9 +3675,13 @@ function FlightSceneContent({
 
             const drift = Math.sin((sceneTime * 0.6) + index) * 0.35;
             const bob = Math.sin((sceneTime * 1.1) + (index * 0.8)) * 0.18;
-            const x = contact.scene_x + drift;
-            const y = contact.scene_y + bob;
-            const z = contact.scene_z;
+            const renderPosition = resolveContactRenderPosition(
+                contact,
+                dockingTemporaryVectorRef.current,
+            );
+            const x = renderPosition.x + drift;
+            const y = renderPosition.y + bob;
+            const z = renderPosition.z;
 
             trafficShip.position.set(x, y, z);
 
@@ -2319,9 +3710,24 @@ function FlightSceneContent({
             ))}
 
             {waypointPosition ? (
-                <mesh ref={waypointRef} position={waypointPosition} visible={showWaypointIndicator}>
-                    <torusGeometry args={[1.1, 0.14, 14, 28]} />
-                    <meshStandardMaterial wireframe emissive="#59d4ff" emissiveIntensity={0.35} />
+                <mesh
+                    ref={waypointRef}
+                    position={waypointPosition}
+                    visible={showWaypointIndicator}
+                    scale={[waypointIndicatorScale, waypointIndicatorScale, waypointIndicatorScale]}
+                    renderOrder={20}
+                >
+                    <torusGeometry args={[1, 0.08, 18, 42]} />
+                    <meshStandardMaterial
+                        color="#8fe7ff"
+                        emissive="#59d4ff"
+                        emissiveIntensity={0.9}
+                        wireframe
+                        transparent
+                        opacity={0.95}
+                        depthTest={false}
+                        toneMapped={false}
+                    />
                 </mesh>
             ) : null}
 
@@ -2362,7 +3768,7 @@ function FlightSceneContent({
 
             {visibleCelestialAnchors
                 .map((contact) => (
-                    <group key={`anchor-${contact.id}`} position={sceneAnchorPosition(contact)}>
+                    <group key={`anchor-${contact.id}`} position={celestialAnchorPosition(contact)}>
                         {contact.body_kind !== "star" ? (
                             <mesh rotation={[Math.PI * 0.18, 0, Math.PI * contactHashUnit(contact)]}>
                                 <icosahedronGeometry
@@ -2469,6 +3875,7 @@ export function FlightScene(props: FlightSceneProps): ReactElement {
         jumpPhase,
         jumpProgress,
         renderProfile,
+        cameraMode = "boresight",
         shipVisualKey,
         stationShapeKey,
         transitStationLabel,
@@ -2483,6 +3890,8 @@ export function FlightScene(props: FlightSceneProps): ReactElement {
         waypointContactId,
         onDockingApproachProgress,
         onDockingApproachComplete,
+        onDockingDebug,
+        dockingRotationMatchEnabled,
         showContactLabels,
         spawnDirective,
         onSpawnDirectiveApplied,
@@ -2525,7 +3934,7 @@ export function FlightScene(props: FlightSceneProps): ReactElement {
         <section className={styles.flightSceneShell}>
             <div className={styles.flightSceneCanvasWrap}>
                 <Canvas
-                    camera={{ position: [0, 2, 6], fov: 62 }}
+                    camera={{ position: [0, 2, 6], fov: 62, near: 0.1, far: 200000 }}
                     dpr={dprRange}
                     className={styles.flightSceneCanvas}
                 >
@@ -2540,6 +3949,7 @@ export function FlightScene(props: FlightSceneProps): ReactElement {
                         <FlightSceneContent
                             jumpPhase={jumpPhase}
                             renderProfile={renderProfile}
+                            cameraMode={cameraMode}
                             shipVisualKey={shipVisualKey}
                             focusedContact={focusedContact}
                             scannerContacts={scannerContacts}
@@ -2552,6 +3962,8 @@ export function FlightScene(props: FlightSceneProps): ReactElement {
                             waypointContactId={waypointContactId}
                             onDockingApproachProgress={onDockingApproachProgress}
                             onDockingApproachComplete={onDockingApproachComplete}
+                            onDockingDebug={onDockingDebug}
+                            dockingRotationMatchEnabled={dockingRotationMatchEnabled}
                             showContactLabels={showContactLabels}
                             spawnDirective={spawnDirective}
                             onSpawnDirectiveApplied={onSpawnDirectiveApplied}

--- a/prd/batch-22-contact-coordinate-authority-sync-plan.md
+++ b/prd/batch-22-contact-coordinate-authority-sync-plan.md
@@ -1,0 +1,320 @@
+# Batch 22 Implementation Plan — Contact Coordinate Authority + Scanner/Chart/Flight Sync
+
+Date: 2026-03-09  
+Owner: Product + Backend + Frontend
+
+## Objective
+
+Stabilize contact rendering and distance behavior across the scanner, local chart, and flight scene so the same object keeps the same identity, distance meaning, and positional authority across all views.
+- Remove coordinate-authority ambiguity between `relative_*_km`, `scene_*`, and frontend-only `presentation_*` fields.
+- Ensure chart, scanner, and flight scene use one deterministic reconstruction path for the same contact.
+- Eliminate visible jumps caused by mixed-unit fallback paths and stale cross-view refresh timing.
+- Make docking distance semantics explicit and consistent between scanner UI and approach HUD.
+- Preserve existing target/waypoint behavior while reducing hidden coupling between render-only and gameplay-authoritative coordinates.
+
+## Why This Batch Next
+
+- Recent investigation found concrete evidence that cross-view contact rendering is currently not governed by a single unambiguous authority model.
+- The highest-risk defect is not cosmetic. It reduces player trust in travel, approach, and target selection by making planets, stations, and other contacts appear to move or change distance arbitrarily.
+- Batch 09, Batch 10, and the current core flight design established identity parity and local-target workflows. This batch is the cleanup and hardening pass needed to make those systems reliable under active flight.
+- This batch reduces regression risk before later combat, convoy, and multiplayer traffic work adds more moving contacts into the same rendering stack.
+
+## PRD Alignment (Required)
+
+Every batch plan must align to `prd/prd.md`.
+
+### PRD Mapping
+
+| Batch Item | PRD Section | Requirement/Story Link | Notes |
+|---|---|---|---|
+| Coordinate authority contract cleanup | 5.3, 5.13, 5.14 | Ship persistence and recovery acceptance | Keep server/world position authority intact while fixing client reconstruction |
+| Tactical scanner/chart/flight parity | 5.3.2, 5.14 | Scanner range and clarity acceptance | Scanner grid remains tactical while list/chart/flight use consistent geometry |
+| Station and docking distance semantics | 5.7, 5.14 | Station navigation and docking flows | Clarify center distance vs docking-port distance |
+| Local chart refresh and snapshot consistency | 5.3.2, 5.13, 5.14 | Stable local navigation UX | Avoid mixed snapshots across chart and scanner |
+| Debuggability and telemetry guardrails | 5.11, 5.12 | Logs and monitoring stories | Add diagnostics for authority source, snapshot epoch, and fallback usage |
+
+### Alignment Rules
+
+- Reference exact PRD section numbers and keep scope tied to existing PRD requirements.
+- This batch is implementation-hardening and contract cleanup; no PRD expansion is required if scope remains additive.
+
+### PRD Update Needed
+
+- None expected, unless a new persistent snapshot/version field becomes user-visible or part of documented API guarantees.
+
+## Core Design Alignment (Required)
+
+Every batch plan must align to long-lived core system design docs in `prd/design/`.
+
+### Design Doc References
+
+- Canonical index: `prd/design/core-system-design-index.md`
+- Impacted design docs:
+  - `prd/design/core-flight-navigation-design.md`
+  - `prd/design/core-stations-locations-design.md`
+  - `prd/design/core-system-design-index.md`
+
+### Design Alignment Rules
+
+- The current flight design doc already states that `relative_*_km` is canonical and `scene_*` is fallback only.
+- This batch must either bring implementation fully into line with that rule or revise the design doc to describe the real multi-layer coordinate model more explicitly.
+- Any threshold-based split between near-field physical rendering and far-field presentation rendering must be documented as a first-class rule, not left implicit in frontend heuristics.
+
+## Execution Status Update (2026-03-09)
+
+Status: Implemented and validated (targeted)
+
+### Implemented in This Iteration
+
+- [x] Batch plan drafted from verified code-review findings.
+- [x] Open scope decisions collected from product/implementation owner.
+- [x] Backend scanner and local-chart payloads now emit shared snapshot metadata.
+- [x] Frontend scanner/chart merge now rejects incompatible snapshots.
+- [x] Local-chart anchoring now uses canonical `relative_*_km` resolution.
+- [x] Celestial anchors now render from physical ship-relative km for this batch.
+- [x] Focused docking approach UI now labels `SURFACE` versus `PORT` distance mode explicitly.
+- [x] Root/backend README notes and changelog entries now document snapshot compatibility fields and docking-distance labeling behavior.
+- [x] Targeted backend/frontend regressions passed after implementation.
+
+### Remaining / Follow-up
+
+- [ ] Execute the manual QA checklist in `prd/batch-22-contact-coordinate-authority-sync-qa-checklist.md` and record before/after evidence for the original “contacts jump around” repro path.
+- [ ] Make an explicit contract decision on docking distance mode after manual QA: keep the current frontend-derived `PORT`/`SURFACE` labeling model, or add backend-visible `distance_mode` metadata in a follow-up if cross-surface drift/debuggability still needs server-side exposure.
+
+## Readiness Checklist (Pre-Implementation Gate)
+
+- [x] Coordinate authority model is chosen and written down in one place.
+- [x] Distance semantics for docking mode are explicitly approved.
+- [x] Refresh/snapshot policy between scanner and chart is defined.
+- [x] Far-field celestial rendering strategy is agreed.
+- [x] Impacted design docs are identified and linked.
+- [x] Validation strategy and manual QA scenarios are documented.
+- [x] Risk rollback path is defined for marker/chart regressions.
+
+## In Scope
+
+### 1) Coordinate Authority Contract
+- Define one canonical meaning for each layer:
+  - `position_*`: absolute world coordinates
+  - `relative_*_km`: canonical ship-relative coordinates
+  - `scene_*`: backend compressed fallback coordinates
+  - `presentation_*`: frontend presentation-only positions if retained
+- Remove mixed-unit interpretation in chart anchoring and any other reconstruction path.
+- Ensure every fallback path is explicit about unit type and intended use.
+
+### 2) Cross-View Position Reconstruction
+- Unify how chart, scanner HUD, flight markers, and flight celestial anchors derive contact positions.
+- Eliminate cases where the same contact is rendered from station-inverse math in one view, raw relative km in another, and synthesized presentation scaling in a third.
+- Use true ship-relative km for celestial anchors across flight-facing surfaces in this batch.
+- Remove dead or misleading presentation-only paths that imply a compressed celestial layout while runtime rendering still prefers canonical relative km.
+
+### 3) Refresh and Snapshot Consistency
+- Make scanner and local chart refresh behavior coherent during active flight.
+- Keep the local chart event-driven in this batch rather than polling it at scanner cadence.
+- Add a shared snapshot/version/epoch strategy so the frontend can detect when chart and scanner payloads came from different world states.
+- Prevent chart refresh lag from making the same contact appear to shift between chart and scanner after ship movement or local transfer by rejecting or deferring mismatched snapshots.
+
+### 4) Distance Semantics Cleanup
+- Standardize which UI surfaces show:
+  - contact center distance,
+  - station surface distance, and/or
+  - docking-port distance.
+- Keep scanner list values stable and readable on center/surface semantics while allowing focused docking approach UI to show docking-port distance.
+- Make the distance-mode difference explicit in code and UI labels/tooling so the two readouts do not look like accidental disagreement.
+
+### 5) Observability and Guardrails
+- Add diagnostics for:
+  - authority source chosen for a rendered contact,
+  - fallback usage frequency,
+  - chart/scanner snapshot mismatch,
+  - docking distance mode.
+- Make it straightforward to debug “why did this contact move” from logs or client debug output.
+
+### 6) Validation
+- Backend tests for consistent contact contract shape and snapshot/version fields.
+- Frontend tests for chart/scanner/flight parity and no mixed-unit fallback.
+- Manual QA across station approach, local transfer to celestial targets, scanner range changes, docking approach, and chart target selection.
+
+## Out of Scope (Explicit)
+
+- Full orbital mechanics simulation or continuously advancing celestial orbits.
+- Major visual redesign of the scanner or chart UI.
+- Combat-flight balancing, NPC traffic AI, or convoy behavior.
+- Replacing the entire flight scene render architecture unless needed later as follow-up work.
+
+## Sound Effects / Audio Feedback (Required)
+
+No new audio event family is required for the core fix. Existing flight/docking cues remain in place.
+
+If UI clarification is added for distance-mode transitions, reuse existing event categories rather than adding a new sound taxonomy in this batch.
+
+Validation criteria:
+- No duplicate or misleading audio cue should trigger solely because chart/scanner contact authority changes internally.
+- Docking approach audio should remain tied to flight phase, not to internal coordinate-source switches.
+
+## Supporting Functionality Required
+
+### Backend Systems
+- Optional additive contact snapshot/version field on scanner and local-chart responses.
+- Clear contract helpers for coordinate-source semantics and any far-field presentation threshold if backend participates.
+- Stable distance-mode metadata where docking-specific distances are exposed.
+
+### Frontend Systems
+- Single coordinate-source resolver used by chart, scanner fallback, waypoint markers, and celestial anchors.
+- Shared snapshot merge behavior for scanner contacts and local chart data.
+- Explicit UI handling for docking distance mode if center vs port semantics remain different.
+- Debug-only instrumentation path for contact authority/fallback tracing.
+
+### Observability and Operations
+- Structured logs or debug traces for selected contact authority source.
+- Regression fixtures covering station, planet, moon, star, and ship contacts.
+- Manual QA checklist for “contact moves unexpectedly” scenarios.
+
+## Data and Contract Additions
+
+- Additive only.
+- Candidate additions:
+  - `snapshot_version` or `snapshot_generated_at` on scanner and local-chart payloads
+  - explicit `distance_mode` on backend contact payloads where needed
+  - optional `coordinate_mode` metadata if the contract needs to distinguish physical vs presentation positions
+- Compatibility constraints:
+  - existing fields remain present during migration
+  - old clients must not break if new metadata is ignored
+  - no silent semantic shift of existing fields without design-doc update
+
+## Scope Decisions Locked for Batch 22
+
+- Far-field rendering: true physical ship-relative km everywhere in this batch.
+- Docking distance policy: stable scanner list distance plus focused docking-port distance is allowed, but the mode split must be explicit.
+- Chart refresh policy: local chart remains event-driven, gated by shared snapshot/version metadata rather than high-frequency polling.
+- Precision scope: keep integer-km contact coordinates for this batch; sub-kilometer precision is a follow-up candidate, not a Batch 22 requirement.
+
+## Implementation Sequence
+
+0. Readiness and design lock
+- Confirm authority model, docking distance policy, and refresh strategy.
+- Update `prd/design/core-flight-navigation-design.md` with final rules before or alongside code changes.
+
+1. Backend contract work
+- Add snapshot/version metadata to scanner and local-chart endpoints.
+- Expose any required distance-mode or coordinate-mode metadata explicitly.
+- Ensure tests lock down contact identity, canonical relative coordinates, and additive response compatibility.
+
+2. Frontend authority resolver
+- Introduce one shared resolver for contact position authority.
+- Remove mixed-unit inverse scaling fallback from chart anchoring and equivalent paths.
+- Make celestial anchor rendering follow the chosen physical ship-relative rule and remove misleading dead-path presentation fallbacks where appropriate.
+
+3. Refresh coordination
+- Coordinate scanner and local-chart refresh logic during active flight and post-transfer/post-docking transitions.
+- Reject or defer mixed snapshot application when payload versions do not match.
+
+4. Distance semantics UX
+- Clearly label docking-port vs center/surface distance behavior rather than forcing one unified value everywhere.
+- Ensure focused target UI and scanner list do not appear contradictory.
+
+5. Validation and docs
+- Add regression tests.
+- Update core design docs and batch status.
+- Record manual QA evidence.
+
+## Concrete Task Checklist
+
+### Backend Slice
+
+- [x] Add shared snapshot metadata to `GET /api/ships/{ship_id}/local-contacts`.
+- [x] Add matching snapshot metadata to `GET /api/systems/{system_id}/local-chart`.
+- [x] Decide whether snapshot metadata is version-only, timestamp-only, or both, and document the contract.
+- [ ] Add explicit distance-mode metadata only if post-fix manual QA shows frontend-derived mode labeling is insufficient for consistency, observability, or future API consumers.
+- [x] Add tests covering additive compatibility of new scanner/local-chart fields.
+- [x] Add tests proving contact IDs and canonical `relative_*_km` remain stable after contract expansion.
+
+### Frontend Slice
+
+- [x] Introduce one shared coordinate-authority resolver for chart/scanner/flight consumers.
+- [x] Remove mixed-unit inverse station-scene fallback from local-chart anchored reconstruction.
+- [x] Replace duplicated ad hoc fallback logic with explicit source-priority helpers.
+- [x] Make celestial anchor rendering use the locked physical ship-relative path consistently.
+- [x] Remove or repurpose dead `presentation_*`-driven celestial fallback paths so implementation matches documented intent.
+- [x] Gate chart/scanner state application on shared snapshot compatibility.
+- [x] Keep local chart event-driven, but reject or defer stale chart/scanner combinations.
+- [x] Make docking distance mode explicit in the focused approach UI and any related labels/tooltips.
+- [x] Preserve waypoint priority and selected-contact behavior while refactoring coordinate logic.
+
+### Test Slice
+
+- [x] Add frontend regression coverage for chart/scanner parity after active flight movement.
+- [x] Add frontend regression coverage for local transfer to station, planet, moon, and star contacts.
+- [x] Add frontend regression coverage for scanner range changes while telemetry remains active.
+- [x] Add frontend regression coverage for docking distance-mode labeling and non-contradictory readouts.
+- [x] Add backend tests for snapshot metadata presence and stability.
+- [ ] Execute `prd/batch-22-contact-coordinate-authority-sync-qa-checklist.md` and attach before/after evidence for the core “contact jumps around” bug class.
+
+### Documentation Slice
+
+- [x] Update `prd/design/core-flight-navigation-design.md` to reflect the locked physical-rendering decision for this batch.
+- [x] Update `prd/design/core-flight-navigation-design.md` to explicitly document snapshot gating between chart and scanner.
+- [x] Update `prd/design/core-stations-locations-design.md` if docking distance semantics become part of location/station design behavior.
+- [x] Update this batch plan status/checklists as implementation lands.
+
+## Acceptance Criteria
+
+- [x] A given contact renders from one documented coordinate authority path across chart, scanner, and flight scene for the same state snapshot.
+- [x] Local chart anchoring no longer applies inverse station scene scaling to mixed-unit live telemetry.
+- [x] Celestial anchors use documented physical ship-relative rendering in this batch, with no dead-path ambiguity from unused presentation fallback logic.
+- [x] Scanner and local chart payloads expose enough metadata for the frontend to detect mixed snapshots.
+- [x] During active flight, chart/scanner state does not visibly desync after ordinary movement, local transfer, or docking approach refreshes when snapshot metadata matches; mismatched payloads are not silently merged.
+- [x] Docking-related distance displays are internally consistent or explicitly labeled by mode.
+- [x] Waypoint priority behavior remains unchanged: docking target > local waypoint > locked contact > locked station ID.
+- [x] Scanner grid behavior remains tactical-range bounded and is not regressed by the coordinate-authority cleanup.
+- [x] Frontend lint and targeted regression suites pass.
+- [x] Backend tests for contact contracts and snapshot metadata pass.
+
+## Risks and Mitigations
+
+- Risk: Fixing authority rules breaks current waypoint or docking visuals.
+  - Mitigation: Add focused regression tests for waypoint priority, docking approach markers, and selected-contact persistence.
+- Risk: Snapshot coordination adds UI latency or missed updates.
+  - Mitigation: Use additive metadata first and fail open in debug builds before enforcing strict gating.
+- Risk: Far-field celestial rendering decision expands scope.
+  - Mitigation: Batch 22 is locked to physical ship-relative rendering; any future far-field presentation layer is a follow-up batch, not hidden scope growth here.
+- Risk: Existing design doc language is too absolute for current render architecture.
+  - Mitigation: Update the design doc and acceptance criteria in the same PR so implementation and docs remain aligned.
+
+## Test and Validation Evidence
+
+- Executed commands:
+  - `backend`: `cd backend && set -a && source ./.env && set +a && PYTHONPATH=. ../.venv/bin/python -m pytest tests/test_players_ships_markets.py tests/test_systems_local_chart.py`
+  - `frontend`: `cd frontend && npm run lint`
+  - `frontend targeted`: `cd frontend && npm run test -- src/app/page.scanner-flight.test.tsx`
+- Results:
+  - backend targeted pytest: `51 passed in 19.35s`
+  - frontend targeted vitest: `69 passed`
+  - frontend lint: passed
+- Manual validation scenarios:
+  - transfer to star/planet/moon
+  - station approach and docking distance readout
+  - scanner range preset changes during active flight
+  - chart/scanner consistency after position sync refreshes
+- Manual QA artifact:
+  - `prd/batch-22-contact-coordinate-authority-sync-qa-checklist.md`
+- Environment notes:
+  - backend targeted pytest requires `TEST_DATABASE_URL` from `backend/.env`
+  - manual QA evidence is still pending capture
+
+## Documentation Update Checklist
+
+- [x] `prd/prd.md` reviewed for alignment.
+- [x] `prd/design/core-system-design-index.md` reviewed for impacted docs.
+- [x] `prd/design/core-flight-navigation-design.md` updated in this batch.
+- [x] `prd/design/core-stations-locations-design.md` reviewed/updated if docking distance semantics change.
+- [x] Batch plan updated with current status.
+- [x] `CHANGELOG.md` updated when user-visible/dev-facing behavior changes.
+- [x] `README.md` and/or `backend/README.md` updated if debug workflows or response contracts change.
+
+## Open Questions / Follow-Up Candidates
+
+1. If true physical ship-relative celestial rendering still proves visually unstable or unreadable after the contract cleanup, should a later batch introduce a documented far-field presentation layer?
+2. If docking distance mode remains confusing after labeling, should a later batch unify all visible distance readouts to one basis?
+3. If event-driven chart refresh plus snapshot gating still feels stale in playtests, should a later batch move chart refresh onto an active-flight cadence?
+4. When combat/traffic density increases, does the contact contract need sub-kilometer precision for close-approach and collision-facing systems?

--- a/prd/batch-22-contact-coordinate-authority-sync-qa-checklist.md
+++ b/prd/batch-22-contact-coordinate-authority-sync-qa-checklist.md
@@ -1,0 +1,300 @@
+# Batch 22 Manual QA Checklist — Contact Coordinate Authority Sync
+
+Date: 2026-03-12  
+Owner: Product + QA + Frontend + Backend
+
+## Objective
+
+Provide a repeatable manual QA checklist and evidence template for the last
+open Batch 22 validation item: proving that the original “contacts jump around”
+bug class is fixed and that docking distance labels remain understandable
+across scanner, chart, and flight surfaces.
+
+## Scope
+
+This checklist covers:
+- chart/scanner snapshot compatibility behavior,
+- local-contact identity and positional stability across view changes,
+- docking distance mode readability (`SURFACE` vs `PORT`),
+- targeted before/after evidence capture for the original repro path.
+
+This checklist does not replace automated tests. It complements:
+- targeted backend pytest in `backend/tests/test_players_ships_markets.py`
+- targeted backend pytest in `backend/tests/test_systems_local_chart.py`
+- targeted frontend vitest in `frontend/src/app/page.scanner-flight.test.tsx`
+
+## Environment Prerequisites
+
+- Backend running with local Batch 22 changes applied.
+- Frontend running against the same backend.
+- Test user with an in-space ship in a system containing at least:
+  - one station,
+  - one planet,
+  - one moon or star contact.
+- Scanner and local chart both reachable from the current gameplay flow.
+- If possible, keep a screen recording running for the repro scenarios.
+
+## Suggested Local Runbook
+
+Use these commands for the current workspace layout.
+
+### 1) Start Backend
+
+```bash
+cd backend
+set -a && source ./.env && set +a
+../.venv/bin/uvicorn app.main:app --reload
+```
+
+Tester notes:
+- This uses the repo `.venv` plus `backend/.env`.
+- If you need to run targeted backend verification first, use:
+
+```bash
+cd backend
+set -a && source ./.env && set +a
+PYTHONPATH=. ../.venv/bin/python -m pytest tests/test_players_ships_markets.py tests/test_systems_local_chart.py
+```
+
+### 2) Start Frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+Tester notes:
+- Open the local Next.js URL shown in the terminal.
+- Login through the app UI so `elite_token` and `elite_user_id` are written to local storage by the normal auth flow.
+
+### 3) Confirm Ship/Test State
+
+Quick ship inspection and top-up helpers:
+
+```bash
+cd backend
+../.venv/bin/python scripts/dev_ship_tools.py status --ship-id 1
+../.venv/bin/python scripts/dev_ship_tools.py top-up --ship-id 1
+```
+
+Tester notes:
+- Use the status command first to confirm the ship is not stuck docked or in an unusable state.
+- Use the top-up command if fuel/energy/shields would otherwise block the movement scenarios.
+- If your active test ship is not `1`, substitute the correct ship ID.
+
+### 4) Optional Sanity Flows
+
+Docking-range sanity check:
+
+```bash
+cd backend
+../.venv/bin/python scripts/smoke_docking_range.py
+```
+
+Jump/local-transfer sanity check:
+
+```bash
+cd backend
+../.venv/bin/python scripts/smoke_jump_modes.py
+```
+
+Tester notes:
+- These are optional pre-QA confidence checks, not substitutes for the manual scenarios below.
+- If either smoke flow fails, fix that first before trusting manual QA results.
+
+## Tester Notes For This Batch
+
+- Prefer one stable commander/save state for the full checklist so selection persistence and contact identity are easier to compare.
+- Start the checklist from an in-space state, not a docked state, unless a scenario says otherwise.
+- When capturing before/after evidence, use the same target contact name across scanner, chart, and flight when possible.
+- For docking-distance checks, capture the exact text shown in the `Dock Target Range` surface.
+- For snapshot mismatch checks, capture the exact text shown when the chart is waiting for a compatible snapshot.
+- If a scenario fails, record whether the problem looked like:
+  - identity drift,
+  - position jump,
+  - distance disagreement,
+  - stale chart/scanner mismatch,
+  - or unclear mode labeling.
+
+## Evidence Capture Rules
+
+For each scenario below, capture the following:
+- `Result`: `Pass` or `Fail`
+- `Before`: short note or screenshot/video reference showing the prior bug or setup state
+- `After`: short note or screenshot/video reference showing the fixed behavior
+- `Observed labels`: exact wording for any `SURFACE`, `PORT`, snapshot mismatch, or target status text
+- `Notes`: anything unexpected, ambiguous, or worth follow-up
+
+Use the template block in each scenario or copy the summary table at the end.
+
+## Scenario 1 — Original Contact-Jump Repro
+
+Goal:
+- Confirm the same contact no longer appears to jump between scanner, local chart,
+  and flight scene during ordinary refresh/update flow.
+
+Steps:
+1. Start in flight with a visible station and at least one celestial contact.
+2. Open Flight mode and note the selected contact name and distance.
+3. Open System mode and confirm the same contact is selected or re-select it.
+4. Trigger ordinary scanner refresh behavior by waiting for the normal update cycle
+   or changing focus between contacts.
+5. Trigger local chart refresh behavior through the normal event-driven path
+   such as target changes, transfer completion, or docking-approach transitions.
+6. Compare the same contact across:
+   - scanner list,
+   - system chart row/selection,
+   - flight scene focused target.
+7. Repeat while moving the ship a modest amount in-system.
+
+Pass criteria:
+- The same contact keeps the same identity across all three surfaces.
+- No visible position or distance jump occurs solely from mixed scanner/chart state.
+- If snapshots are incompatible, the chart defers with an explicit waiting/error state
+  instead of silently rendering mismatched geometry.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Scenario 2 — Snapshot Mismatch Guardrail
+
+Goal:
+- Confirm the frontend rejects mixed scanner/chart snapshots instead of merging them.
+
+Steps:
+1. Start in flight and open System mode.
+2. Create or wait for a state transition that changes local-space generation/snapshot state.
+3. Observe local chart behavior while scanner data and chart data are temporarily out of sync.
+
+Pass criteria:
+- Local chart does not silently merge incompatible data.
+- The UI shows an explicit compatibility wait state such as
+  `Local chart awaiting compatible snapshot.`
+- Once compatible data arrives, chart content resumes normally.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Scenario 3 — Station Approach Distance Consistency
+
+Goal:
+- Confirm station targeting remains readable before docking approach begins.
+
+Steps:
+1. Select a station target in Flight mode without starting docking approach.
+2. Observe the dock target range label and scanner list distance.
+3. Compare scanner/list/flight text for the same target.
+
+Pass criteria:
+- Distance labels are stable and readable.
+- Pre-approach station targeting uses the expected non-port label basis.
+- No contradictory or unexplained distance text is shown.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Scenario 4 — Active Docking Approach Port Labeling
+
+Goal:
+- Confirm the focused docking approach UI explicitly switches to `PORT` mode when appropriate.
+
+Steps:
+1. Select a station target in Flight mode.
+2. Start docking approach.
+3. Observe the focused dock target range text during active approach.
+4. Compare it with the pre-approach state from Scenario 3.
+
+Pass criteria:
+- Active docking approach clearly indicates `PORT` distance mode when that mode is in effect.
+- The label change appears intentional, not like conflicting data.
+- Any in-range/out-of-range message remains understandable with the mode label.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Scenario 5 — Local Transfer to Celestial Target
+
+Goal:
+- Confirm local transfer or ordinary movement toward a planet, moon, or star does not
+  cause cross-surface authority drift.
+
+Steps:
+1. Select a planet, moon, or star target.
+2. Perform the normal local transfer or manual approach flow.
+3. Observe scanner distance, chart selection, and flight-scene focus before and after movement.
+
+Pass criteria:
+- Contact identity remains stable.
+- Distances change smoothly and plausibly.
+- No sudden fallback-style positional jump appears on chart refresh.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Scenario 6 — Scanner Range Preset Changes During Flight
+
+Goal:
+- Confirm scanner tactical-range changes do not break contact identity or chart parity.
+
+Steps:
+1. Start in Flight mode with multiple contacts in range and out of range.
+2. Change scanner presets across at least two values.
+3. Compare scanner grid visibility, scanner list distances, and chart/flight selection state.
+
+Pass criteria:
+- Grid visibility changes with range presets as expected.
+- Contact list identity and selected-contact parity remain stable.
+- No contact appears to “teleport” because of a range preset change.
+
+Evidence template:
+- Result:
+- Before:
+- After:
+- Observed labels:
+- Notes:
+
+## Follow-Up Decision Gate
+
+After completing the checklist, answer this explicitly:
+
+`Is the current frontend-derived docking distance mode sufficient?`
+
+Choose one:
+- `Yes`: keep current model; no backend `distance_mode` field needed now.
+- `No`: create a follow-up item to add backend-visible `distance_mode` metadata.
+
+Decision notes:
+- Reason:
+- Evidence references:
+- Follow-up issue/doc link:
+
+## Summary Table
+
+| Scenario | Result | Before Evidence | After Evidence | Notes |
+|---|---|---|---|---|
+| Original contact-jump repro | TBD |  |  |  |
+| Snapshot mismatch guardrail | TBD |  |  |  |
+| Station approach distance consistency | TBD |  |  |  |
+| Active docking approach port labeling | TBD |  |  |  |
+| Local transfer to celestial target | TBD |  |  |  |
+| Scanner range preset changes | TBD |  |  |  |

--- a/prd/design/core-flight-navigation-design.md
+++ b/prd/design/core-flight-navigation-design.md
@@ -1,21 +1,27 @@
 # Core System Design — Ship Flight and Navigation
 
 Status: Active  
-Last Updated: 2026-03-04  
+Last Updated: 2026-03-09  
 Owners: Product + Backend + Frontend
 
 ## Objective
 
-- Define authoritative in-system flight, scanner behavior, docking constraints,
-  and hyperspace navigation behavior.
+- Define the canonical model for local-space flight, hyperspace travel,
+  scanner telemetry, local/system chart behavior, waypoint tracking, docking,
+  and 3D scene rendering.
+- Document which coordinate spaces are authoritative, which are presentation
+  only, and how contacts must be tracked consistently across backend and
+  frontend.
 
 ## PRD Alignment
 
 | Design Area | PRD Section | Requirement/Story Link | Notes |
 |---|---|---|---|
-| Flight metrics and authority | 5.3, 7.2 | Persistent ship movement and metrics | Server-authoritative state |
-| Jump mechanics | 5.3.1 | Jump constraints and misjump behavior | Deterministic constraints |
-| Scanner behavior | 5.3.2 | Tactical scanner range/scale | True-distance list labels |
+| Ship movement and persistence | 5.3, 5.13, 5.14 | Persistent ship/location state | Server authority for mutable ship state |
+| Hyperspace and local transfer | 5.3.1, 5.14 | Fuel/range/travel constraints | Distinct hyperspace vs in-system transfer paths |
+| Scanner and tactical contacts | 5.3.2, 5.7, 5.14 | Tactical scanner range and local awareness | True-distance list labels and stable contact identity |
+| Station/planet approach and docking | 5.7, 5.14 | Navigation to stations and locations | Docking corridor and local waypoint flow |
+| Logs and observability | 5.11, 5.12 | Admin/system monitoring stories | Flight, chart, scanner, and jump diagnostics |
 
 ### PRD Update Needed
 
@@ -24,19 +30,183 @@ Owners: Product + Backend + Frontend
 ## System Scope
 
 ### In Scope
-- Flight state updates, scanner presets/display rules, docking constraints,
-  jump planning/execution behavior.
+- Ship position, velocity, fuel, jump phase, and destination lock state.
+- Local contact generation for stars, planets, moons, stations, and ships.
+- Contact identity and coordinate contracts across backend and frontend.
+- Scanner list, scanner HUD, flight scene markers, local chart rows, and
+  galactic jump-planning interactions.
+- Docking approach, local transfer, hyperspace jump, collision checks, and
+  position synchronization.
 
 ### Out of Scope
-- Full orbital physics simulation.
+- Full orbital mechanics simulation with continuous gravity integration.
+- Newtonian combat flight model.
+- Autonomous NPC navigation authority beyond contact presentation.
 
 ## Domain Model
 
-- Ship position/velocity state, scanner contacts, jump state.
+- Authoritative ship state:
+  - Persisted on the backend in ship world coordinates:
+    `position_x`, `position_y`, `position_z`, `velocity_x`, `velocity_y`,
+    `velocity_z`, `status`, `flight_phase`, and destination lock fields.
+- Contact identity:
+  - Canonical frontend/backend shared identity is string form
+    `<contact_type>-<numeric_id>`.
+  - Valid local target contact types are `station`, `planet`, `moon`, `star`.
+  - Ship contacts are trackable scanner contacts but not valid local-transfer
+    or docking targets.
+- Contact coordinate layers:
+  - `position_*` on world entities and ships are authoritative absolute world
+    positions in kilometers.
+  - `relative_*_km` on local contacts are the canonical ship-relative contact
+    positions in kilometers.
+  - `scene_*` are compressed presentation coordinates used only when canonical
+    relative positions are unavailable.
+  - `presentation_*` are frontend-only celestial fallback positions for scene
+    layout when local chart-derived relative coordinates are synthesized.
+  - `chart_*` are chart display coordinates derived from authoritative world
+    positions or from anchored relative positions, not an independent source of
+    truth.
+- Waypoint and target state:
+  - Station hyperspace target is tracked through locked destination station and
+    contact fields.
+  - In-system waypoint/transfer target is tracked through local target contact
+    identity and local waypoint UI state.
+  - Docking approach target is a stronger temporary override while the ship is
+    inside the docking approach phase.
 
 ## Runtime Behavior
 
-- Tick-driven flight updates and scanner telemetry refresh.
+### 1. World-Space Authority
+
+- Backend ship state is authoritative for all persistent space mechanics.
+- `POST /api/ships/{ship_id}/position-sync` updates persisted ship world
+  position from the active flight scene when the client is in a stable local
+  flight state.
+- `POST /api/ships/{ship_id}/flight-state` persists current phase and locked
+  destination identity so the frontend can restore flight context after reload
+  or subsequent fetches.
+
+### 2. Contact Generation and Identity
+
+- `GET /api/ships/{ship_id}/local-contacts` produces the active in-system
+  contact set.
+- Local contacts include stars, planets, moons, stations, and other ships in
+  the current system.
+- Each contact carries:
+  - stable `id`
+  - `contact_type`
+  - user-facing `name`
+  - true `distance_km`
+  - optional structural metadata such as `body_type`, `radius_km`,
+    `orbit_radius_km`, `orbiting_planet_name`, `station_archetype_shape`, and
+    `ship_visual_key`
+  - canonical `relative_x_km`, `relative_y_km`, `relative_z_km`
+  - compressed `scene_x`, `scene_y`, `scene_z` fallback coordinates
+- Rule:
+  - If a contact has `relative_*_km`, all flight, scanner, marker, and chart
+    systems must prefer that data over `scene_*`.
+
+### 3. Scanner Model
+
+- Scanner behavior has two distinct surfaces:
+  - contact list and detail panels driven from snapshot backend contacts
+  - HUD/grid blips driven from live flight-scene telemetry with backend
+    snapshot fallback
+- Distance policy:
+  - display distance is snapshot-first so list values stay stable and readable
+  - live distance is only used when snapshot distance is unavailable
+- Projection policy:
+  - HUD placement uses canonical plane projection from ship-relative contact
+    pose
+  - altitude no longer determines whether an in-range blip may appear on the
+    scanner grid
+  - `scene_*` fallback is only used when no canonical relative position exists
+- Selection policy:
+  - scanner selection is a UI focus mechanism, not an authority source for
+    flight state
+  - `POST /api/ships/{ship_id}/scanner-selection` records selected contact
+    diagnostics/telemetry only
+
+### 4. Local Chart and World Reconstruction
+
+- `GET /api/systems/{system_id}/local-chart` provides the structured star,
+  planets, moons, stations, and mutable local target state for the current
+  system.
+- The frontend local chart reconstructs contact positions by preferring:
+  1. anchored world position derived from a known station world coordinate plus
+     live `relative_*_km`
+  2. backend contact `relative_*_km`
+  3. compressed fallback coordinates only when neither of the above exists
+- Result:
+  - chart rows are not a separate truth source
+  - chart, scanner, and flight scene should describe the same target set using
+    the same stable contact IDs and the same relative/world geometry basis
+
+### 5. Flight Scene Rendering
+
+- The 3D flight scene uses contact identity shared with scanner/chart state.
+- Rendering order of trust for positions:
+  1. `relative_*_km` for near-field local rendering
+  2. synthesized celestial anchor positions from local chart + contact parity
+  3. `scene_*` only as fallback presentation data
+- Marker policy:
+  - focused contact marker and waypoint marker resolve from the same canonical
+    contact ID model
+  - docking approach target overrides generic waypoint target
+  - local waypoint contact overrides generic destination lock when both exist
+  - waypoint torus visibility depends on a resolved waypoint target position,
+    not merely jump phase labels
+- Station rendering:
+  - station visual shape is driven by `station_archetype_shape`
+  - docking port position is derived deterministically from the station model
+    and shape-specific anchor data
+  - docking visuals may add presentation detail, but may not redefine target
+    identity or contact position authority
+
+### 6. Waypoint Tracking and Target Priority
+
+- Canonical target priority in flight-facing UI:
+  1. active docking approach target
+  2. explicit local waypoint contact
+  3. locked destination contact
+  4. locked destination station expressed as `station-<id>`
+- Rationale:
+  - local system navigation can legitimately maintain both a generic locked
+    destination and a specific local waypoint, especially for planets/stars
+  - the explicit local waypoint is the stronger user intent for in-system
+    travel and marker rendering
+- Local chart waypoint toggle behavior:
+  - station selection locks station destination and clears local waypoint state
+  - planet/star/moon selection locks the specific local target contact and may
+    also populate generic destination-contact fields for persistence parity
+
+### 7. Local Transfer and Hyperspace
+
+- Hyperspace jump:
+  - `POST /api/ships/{ship_id}/jump`
+  - used for system-to-system travel via a destination station/system pair
+  - requires fuel and safe exit constraints
+- Local transfer:
+  - `POST /api/ships/{ship_id}/local-target` with action `transfer`
+  - used for in-system relocation toward a locked station, planet, moon, or star
+  - writes authoritative ship position near the target in world space
+- Celestial transfer rule:
+  - transfer placement for stars/planets/moons must use body radius plus
+    standoff distance, never a raw center-point offset only
+  - this keeps post-transfer ship placement physically outside large bodies and
+    keeps scanner/chart/render distance behavior coherent
+
+### 8. Docking and Position Sync
+
+- Docking is a local in-system maneuver layered on top of the same contact and
+  waypoint model.
+- `POST /api/ships/{ship_id}/dock` validates docking-computer range and target
+  station rules.
+- During docking approach, the frontend may sync ship position to keep backend
+  world state aligned with the rendered final docking path.
+- Docking computer/collision safety corridor temporarily suppresses collision
+  responses that would conflict with deterministic docking completion.
 
 ## Current State Starter (Batches 01-11)
 
@@ -55,38 +225,133 @@ Owners: Product + Backend + Frontend
 - Galactic chart and hyperspace navigation are completed with mode switching,
   reachability evaluation, and destination overview contracts (`Batch 11`).
 
-## Code-Truth Update (2026-03-04)
+## Code-Truth Update (2026-03-09)
 
-- Backend status: verified active ship flight/scanner endpoints (including
-  local contacts, operations, docking, jump, collision-check, recovery,
-  flight-state, position-sync, and cargo) plus systems chart/overview APIs.
-- Frontend status: verified active runtime calls across these
-  flight/navigation API surfaces.
+- Backend status: verified active ship flight/scanner endpoints:
+  - `GET /api/ships/{ship_id}`
+  - `GET /api/ships/{ship_id}/local-contacts`
+  - `GET /api/ships/{ship_id}/operations`
+  - `POST /api/ships/{ship_id}/scanner-selection`
+  - `POST /api/ships/{ship_id}/dock`
+  - `POST /api/ships/{ship_id}/undock`
+  - `POST /api/ships/{ship_id}/jump`
+  - `POST /api/ships/{ship_id}/local-target`
+  - `POST /api/ships/{ship_id}/collision-check`
+  - `POST /api/ships/{ship_id}/crash-recovery`
+  - `POST /api/ships/{ship_id}/flight-state`
+  - `POST /api/ships/{ship_id}/position-sync`
+- Backend status: verified active systems endpoints:
+  - `GET /api/systems/galaxy/systems`
+  - `GET /api/systems/galaxy/systems/{system_id}/overview`
+  - `GET /api/systems/{system_id}/local-chart`
+- Backend contacts now expose physical relative fields on local contacts.
+- Frontend runtime actively uses the above surfaces for scanner, chart, flight
+  scene, docking, jump, and collision flows.
+- Frontend now treats canonical relative contact pose as the primary basis for:
+  - scanner HUD blips
+  - celestial markers
+  - waypoint/focus markers
+  - local chart row placement
+- `scene_*` remains a fallback display contract, not the primary local-space
+  truth when `relative_*_km` is present.
 
 ## API and Data Contracts
 
-- Ship and scanner APIs with additive fields only for new telemetry.
+### Contact Contract
+
+| Field Group | Purpose | Canonical Use |
+|---|---|---|
+| `id`, `contact_type`, `name` | Stable identity and display naming | Shared across scanner, chart, flight, waypoints |
+| `distance_km` | Snapshot contact distance | Scanner lists, chart rows, status text |
+| `relative_x_km`, `relative_y_km`, `relative_z_km` | Physical ship-relative position in km | Primary input for render, marker, and chart alignment |
+| `scene_x`, `scene_y`, `scene_z` | Compressed presentation position | Fallback only |
+| `radius_km`, `body_type`, `orbit_*`, `station_archetype_shape`, `ship_visual_key` | Visual and contextual metadata | Scene rendering and detail surfaces |
+
+### Ship Flight Contract
+
+- Persisted flight fields:
+  - `flight_phase`
+  - `flight_locked_destination_station_id`
+  - `flight_locked_destination_contact_type`
+  - `flight_locked_destination_contact_id`
+- Local target state must remain additive/backward-compatible:
+  - station lock remains supported for legacy flow compatibility
+  - generic contact lock carries the authoritative non-station target identity
+
+### Chart Contract
+
+- Local chart returns:
+  - system/star/planet/moon/station structural data
+  - mutable local target state
+  - deterministic body IDs that must match scanner contact IDs by type/id pair
+- Frontend chart display coordinates are derived presentation outputs and must
+  not be treated as a new persisted coordinate system.
 
 ## Failure Modes and Guardrails
 
-- Desync between visual and list telemetry, invalid jump attempts,
-  docking-state race conditions.
+- Coordinate-space drift:
+  - scanner, chart, and flight scene must not each invent separate target
+    positions for the same contact
+- Target-state drift:
+  - local waypoint state must not be hidden behind weaker generic destination
+    lock precedence
+- Fallback leakage:
+  - `scene_*` fallback must not silently override valid `relative_*_km`
+    contracts
+- Invalid travel transitions:
+  - local transfer requires in-space state and valid in-system target contact
+  - hyperspace jump requires fuel, cooldown clearance, and valid destination
+- Celestial transfer placement bug class:
+  - stars/planets/moons must never place the ship near body center after
+    transfer
+- Docking-state race conditions:
+  - docking approach, dock request, position sync, and collision safety
+    corridor must remain phase-aware
 
 ## Observability and Operations
 
-- Flight tick latency, scanner update cadence, jump failure reasons.
+- Measure and monitor:
+  - flight tick / frame update health
+  - scanner refresh cadence and response errors
+  - local-chart sync success/failure
+  - jump and local-transfer failure reasons
+  - docking debug events and completion timing
+  - collision-check frequency and recovery outcomes
+- Logging expectations:
+  - scanner/chart/flight target IDs should be comparable in logs
+  - local-target and docking operations should record resolved contact identity
+  - admin/support diagnostics must be able to answer which contact was locked,
+    rendered, transferred toward, and docked against
 
 ## Validation and Test Evidence
 
 - Frontend tests:
-  - `npm run test -- scanner-flight`
+  - `npm run lint`
+  - `npm run test -- page.scanner-flight.test.tsx`
+  - `npm run test -- scannerDistance.test.ts`
+  - `npm run test -- FlightScene.controls.test.ts`
+  - `npm run test -- FlightScene.docking.test.ts`
+- Backend tests:
+  - `pytest backend/tests/test_players_ships_markets.py`
+  - `pytest backend/tests/test_systems_local_chart.py`
+- Verified regression themes covered in tests:
+  - canonical scanner plane projection
+  - snapshot-first scanner distance display
+  - waypoint propagation into flight scene
+  - additive local contact `relative_*_km` contracts
+  - local transfer placement outside planetary radius
 
 ## Open Questions
 
-- None currently.
+- Whether long-range celestial presentation needs an explicit documented scale
+  contract beyond current fallback/presentation rules if richer orbital motion
+  is introduced later.
+- Whether scanner and chart should expose more explicit debug overlays for
+  contact source selection (`relative_*_km` vs fallback) in developer mode.
 
 ## Batch Change Log
 
 - 2026-03-04 — Governance setup — Created persistent flight/navigation design doc.
 - 2026-03-04 — Seeded current-state starter from Batches 01-11.
 - 2026-03-04 — Code-truth audit — Verified implementation state against audited backend and frontend code.
+- 2026-03-09 — Space mechanics rewrite — Expanded doc to define authoritative world space, contact identity, scanner/chart/render contracts, waypoint priority, and local transfer rules.


### PR DESCRIPTION
## Summary
- unify Batch 22 contact/scanner/chart/flight coordinate authority and snapshot compatibility handling
- add the remaining page-level regression coverage for `PORT` vs `SURFACE` docking distance labeling
- update Batch 22 plan, QA checklist, README docs, and changelog to reflect the current implementation state

## Validation
- Not rerun in the clean PR worktree per request
- Previously validated in the source worktree with:
  - `cd frontend && npm run test -- src/app/page.scanner-flight.test.tsx`
  - `cd frontend && npm run lint`
  - targeted backend pytest for local contacts/local chart coverage

## Follow-up still intentionally open
- execute the manual QA checklist and attach evidence for the original contact-jump repro path
- decide after QA whether backend-visible `distance_mode` metadata is needed beyond the current frontend-derived labeling